### PR TITLE
feat: log client server url

### DIFF
--- a/packages/falcon-client/src/index.js
+++ b/packages/falcon-client/src/index.js
@@ -39,7 +39,7 @@ httpServer.listen(process.env.PORT || 3000, error => {
     Logger.error(error);
   }
 
-  Logger.log('🚀  started');
+  Logger.log(`🚀  Client ready at http://localhost:${process.env.PORT}`);
   server.started();
 });
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
The client server logs `started` when it's created.

**What is the new behavior (if this is a feature change)?**
The client server logs `Client ready at http://localhost:PORT` when it's created.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

**Other information:**
Just thought it might be worth having the url to the client server logged when the server is ready, I know it's mentioned in the docs but since the server side already does this I though it might be worth keeping it consistent and easier to remember.

| Before | After |
| --- | --- |
| <img width="417" alt="screen shot 2018-10-07 at 6 21 19 pm" src="https://user-images.githubusercontent.com/661330/46584702-62e96680-ca5e-11e8-9bec-3c68da1e0b97.png"> | <img width="401" alt="screen shot 2018-10-07 at 6 21 50 pm" src="https://user-images.githubusercontent.com/661330/46584706-6a107480-ca5e-11e8-9407-07562f93c6af.png"> |




