### PR TITLE
Do not render dropdown's items if the dropdown is closed

### DIFF
--- a/packages/falcon-ui/src/components/Dropdown.tsx
+++ b/packages/falcon-ui/src/components/Dropdown.tsx
@@ -88,7 +88,7 @@ export const DropdownLabel = themed({
 
 const DropdownMenuInnerDOM: React.SFC<any> = props => (
   <DropdownContext.Consumer>
-    {({ open }) => <Box as="ul" {...props} display={open ? 'block' : 'none'} />}
+    {({ open }) => (open ? <Box as="ul" {...props} display={open ? 'block' : 'none'} /> : null)}
   </DropdownContext.Consumer>
 );
 


### PR DESCRIPTION
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Dropdown component doesn't render its children when it's closed - that way it doesn't affect the performance when there's a lot of items in the dropdown.
