### PR TITLE
Use correct token when fetching product data and breadcrumbs from new api

### DIFF
--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -640,7 +640,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * @return {Promise<Product>} product data
    */
   async product(obj, { id }) {
-    const productData = await this.get(`/products/${id}`);
+    const productData = await this.get(`/products/${id}`, {}, { context: { useAdminToken: true } });
     const product = this.reduceProduct(productData);
     return product;
   }
@@ -1634,7 +1634,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * @return {Promise<[Breadcrumb]>} breadcrumbs fetched from backend
    */
   async breadcrumbs(obj, { path }) {
-    const resp = await this.get(`/breadcrumbs`, { url: path.replace(/^\//, '') });
+    const resp = await this.get(`/breadcrumbs`, { url: path.replace(/^\//, '') }, { context: { useAdminToken: true } });
     return this.convertBreadcrumbs(this.convertKeys(resp.data));
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes logic for fetching product data and breadcrumbs when user is signed in.

**What is the current behavior? (You can also link to an open issue here)**
Code uses wrong token when user is signed in so product data and breadcrumbs cannot be fetched.

