### PR TITLE
fix: remove defaultLocale from api classes as we don't use it anymore

### DIFF
--- a/packages/falcon-magento2-api/src/Magento2ApiBase.js
+++ b/packages/falcon-magento2-api/src/Magento2ApiBase.js
@@ -71,7 +71,6 @@ module.exports = class Magento2ApiBase extends ApiDataSource {
     }));
     this.storeConfigMap = _.keyBy(activeStoreConfigs, 'code');
     this.magentoConfig.locales = _.uniq(activeStoreConfigs.map(x => x.locale));
-    this.magentoConfig.defaultLocale = activeStoreConfigs.find(x => x.code === 'default').locale;
 
     activeStoreWebsites.forEach(storeWebsite => {
       const groups = [];

--- a/packages/falcon-server/src/containers/ExtensionContainer.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.js
@@ -14,7 +14,6 @@ const BaseContainer = require('./BaseContainer');
 /**
  * @typedef {object} BackendConfig
  * @property {string[]} locales
- * @property {string} defaultLocale
  */
 
 /**
@@ -122,7 +121,6 @@ module.exports = class ExtensionContainer extends BaseContainer {
       }
 
       return {
-        defaultLocale: prev.defaultLocale || current.defaultLocale,
         locales: mergedLocales
       };
     }, {});

--- a/packages/falcon-wordpress-api/src/index.js
+++ b/packages/falcon-wordpress-api/src/index.js
@@ -83,7 +83,6 @@ module.exports = class WordpressApi extends ApiDataSource {
       }, {});
 
       this.wpConfig.locales = Object.keys(this.languageMap) || [];
-      this.wpConfig.defaultLocale = this.wpConfig.locales.find(x => this.languageMap[x] === this.baseLanguage);
     }
 
     return this.wpConfig;


### PR DESCRIPTION
Fixes #341 - removed `defaultLocale` from api classes as we don't use that property anymore.