### PR TITLE
[Experiment/RFC] CustomerRequiredDirective

### DIFF
--- a/packages/falcon-magento2-api/package.json
+++ b/packages/falcon-magento2-api/package.json
@@ -41,7 +41,6 @@
     "@deity/falcon-shop-extension": "^0.3.2",
     "eventemitter2": "5.0.1",
     "graphql": "^14.1.1",
-    "graphql-tools": "4.0.4",
     "nock": "10.0.4"
   },
   "gitHead": "d8cd5eede81220aa29563275dcf35448611cc194"

--- a/packages/falcon-magento2-api/src/schemaDirectives.js
+++ b/packages/falcon-magento2-api/src/schemaDirectives.js
@@ -1,0 +1,21 @@
+const { SchemaDirectiveVisitor } = require('graphql-tools');
+
+class CustomerRequired extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    const { resolve: defaultFieldResolver } = field;
+    field.resolve = async (...args) => {
+      const context = args[2];
+      // TODO: use the actual API name instead of "magento2"
+      const session = context.dataSources.magento2.session || {};
+      const { customerToken = {} } = session;
+      if (!customerToken.token) {
+        throw new Error(`Customer token required to read "${field.name}" data`);
+      }
+      return defaultFieldResolver.apply(this, args);
+    };
+  }
+}
+
+module.exports = {
+  customerRequired: CustomerRequired
+};

--- a/packages/falcon-server-env/src/events.ts
+++ b/packages/falcon-server-env/src/events.ts
@@ -25,6 +25,7 @@ export enum Events {
   BEFORE_ENDPOINTS_REGISTERED = 'falcon-server.before-endpoints-registered',
   AFTER_ENDPOINTS_REGISTERED = 'falcon-server.after-endpoints-registered',
 
+  API_DATA_SOURCE_LOADED = 'falcon-server.api-data-source-loaded',
   API_DATA_SOURCE_REGISTERED = 'falcon-server.api-data-source-registered',
   EXTENSION_REGISTERED = 'falcon-server.extension-registered'
 }

--- a/packages/falcon-server/src/containers/ApiContainer.js
+++ b/packages/falcon-server/src/containers/ApiContainer.js
@@ -41,6 +41,10 @@ module.exports = class ApiContainer extends BaseContainer {
         if (!ApiClass) {
           return;
         }
+
+        // TODO: find a better way of propagating GQL config from API to the GQL Server
+        this.eventEmitter.emit(Events.API_DATA_SOURCE_LOADED, ApiClass);
+
         const apiInstanceCb = apolloServerConfig => {
           /** @type {ApiDataSource} */
           const apiInstance = new ApiClass({

--- a/packages/falcon-server/src/containers/ExtensionContainer.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.js
@@ -169,6 +169,7 @@ module.exports = class ExtensionContainer extends BaseContainer {
           resolvers: config.resolvers
         })
       ],
+      schemaDirectives: config.schemaDirectives,
       resolvers: config.resolvers
     });
 

--- a/packages/falcon-shop-extension/src/schema.graphql
+++ b/packages/falcon-shop-extension/src/schema.graphql
@@ -1,3 +1,5 @@
+directive @customerRequired on FIELD_DEFINITION
+
 extend type Query {
   menu: [MenuItem]
   category(id: String!): Category
@@ -12,11 +14,11 @@ extend type Query {
   ): ProductList
   cart: Cart
   countries: CountryList
-  order(id: Int!): Order
+  order(id: Int!): Order @customerRequired
   lastOrder: Order
-  orders(pagination: PaginationInput): Orders
-  address(id: Int!): Address
-  addresses: AddressList
+  orders(pagination: PaginationInput): Orders @customerRequired
+  address(id: Int!): Address @customerRequired
+  addresses: AddressList @customerRequired
   customer: Customer
   cmsPage(id: Int, identifier: String): CmsPage
   cmsBlock(identifier: String): CmsBlock
@@ -35,13 +37,13 @@ extend type Mutation {
   signUp(input: SignUp!): Boolean
   signIn(input: SignIn!): Boolean
   signOut: Boolean
-  editCustomer(input: CustomerInput!): Customer
-  editAddress(input: EditAddressInput!): Address
-  addAddress(input: AddAddressInput!): Address
+  editCustomer(input: CustomerInput!): Customer @customerRequired
+  editAddress(input: EditAddressInput!): Address @customerRequired
+  addAddress(input: AddAddressInput!): Address @customerRequired
   estimateShippingMethods(input: EstimateShippingInput!): [ShippingMethod]
-  removeCustomerAddress(id: Int!): Boolean
+  removeCustomerAddress(id: Int!): Boolean @customerRequired
   requestCustomerPasswordResetToken(input: EmailInput!): Boolean
-  changeCustomerPassword(input: CustomerPassword!): Boolean
+  changeCustomerPassword(input: CustomerPassword!): Boolean @customerRequired
   resetCustomerPassword(input: CustomerPasswordReset!): Boolean
   # set current customer order shipping information
   setShipping(input: ShippingInput): ShippingInformation


### PR DESCRIPTION
### What kind of change does this PR introduce?
In order to reduce the amount of repetitive code and use all available features of GraphQL - I'd suggest using directives to control some parts (queries/mutations) of our GQL instance.

### What is the current behavior?
Currently, our assigned API has to decide and check the required data for a certain list of Queries/Mutations by performing the same check in every assigned method.

### What is the new behavior?
In order to follow the agnostic approach even further - our Extension's GQL Schema must define such checks for every assigned Query and Mutation, to provide the expected result and behavior on the Falcon-Client side (like error code). From the Extension perspective - it knows the context for the specific Q/M, thus it can require some specific directives to be applied on the schema level.

### Other information
Since the Extension has to "assign" such directives to the specific Queries/Mutations - I'd suggest moving `CustomerDirective` defintion to the Extension itself, but this brings another problem - our APIs must manage the token in the same way (to be able to check the customer token). For the sake of PoC - I placed it with the `magento2-api` package (but for sure - it's not the best place to keep it).

---

This is an **experiment** and **RFC** pull-request to discuss such approach before the actual implementation (to public API). **This PR won't be merged**