### PR TITLE
Fix checkout issue

### DIFF
--- a/packages/falcon-ecommerce-uikit/src/Checkout/CheckoutLogic.tsx
+++ b/packages/falcon-ecommerce-uikit/src/Checkout/CheckoutLogic.tsx
@@ -97,8 +97,6 @@ export type CheckoutLogicProps = WithApolloClient<{
 }>;
 
 class CheckoutLogicImpl extends React.Component<CheckoutLogicProps, CheckoutLogicState> {
-  private isComponentMounted: boolean; // eslint-disable-line react/sort-comp
-
   constructor(props: CheckoutLogicProps) {
     super(props);
     this.state = {
@@ -108,24 +106,9 @@ class CheckoutLogicImpl extends React.Component<CheckoutLogicProps, CheckoutLogi
       availablePaymentMethods: [],
       availableShippingMethods: []
     };
-    this.isComponentMounted = false;
-  }
-
-  componentDidMount() {
-    this.isComponentMounted = true;
-  }
-
-  componentWillUnmount() {
-    this.isComponentMounted = false;
   }
 
   setPartialState(partial: any, callback?: () => void) {
-    // make sure that setState() is not called after component has been unmounted - we need that guard
-    // as ApolloClient sometimes call finish callback twice. In that case CheckoutLogic might already be
-    // unmounted when ApolloClient calls the finish callback again - that would print React's warning
-    if (!this.isComponentMounted) {
-      return;
-    }
     this.setState(
       state =>
         // "deep replace" - replace old values with new, don't merge these

--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -1648,12 +1648,18 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   }
 
   /**
-   * Removes unnecesary fields from address entry so Magento doesn't crash
+   * Removes unnecessary fields from address entry and adds proper id so Magento doesn't crash
    * @param {AddressInput} address - address to process
    * @return {AddressInput} processed address
    */
   prepareAddressForOrder(address) {
     const data = { ...address };
+    // if that's a saved addr it will have proper id - in this case we have to add customer_address_id field
+    // as magento accepts that one (not plain "id")
+    if (data.id) {
+      data.customer_address_id = data.id;
+      delete data.id;
+    }
     delete data.defaultBilling;
     delete data.defaultShipping;
     return data;
@@ -1679,6 +1685,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
     const cartPath = this.getCartPath();
 
     const falconPrefix = FALCON_CART_ACTIONS.indexOf(path) === -1 ? '' : '/falcon';
+
+    console.log(method.toUpperCase(), `${falconPrefix}${cartPath}${path}`, JSON.stringify(data, null, 2));
 
     const response = await this[method](`${falconPrefix}${cartPath}${path}`, method === 'get' ? null : data);
 

--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -1686,7 +1686,6 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
     const falconPrefix = FALCON_CART_ACTIONS.indexOf(path) === -1 ? '' : '/falcon';
 
-    console.log(method.toUpperCase(), `${falconPrefix}${cartPath}${path}`, JSON.stringify(data, null, 2));
 
     const response = await this[method](`${falconPrefix}${cartPath}${path}`, method === 'get' ? null : data);
 

--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -1686,7 +1686,6 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
     const falconPrefix = FALCON_CART_ACTIONS.indexOf(path) === -1 ? '' : '/falcon';
 
-
     const response = await this[method](`${falconPrefix}${cartPath}${path}`, method === 'get' ? null : data);
 
     const cartData = this.convertKeys(response.data);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
There are 2 changes:
1. Removed workaround (introduced in commit 9b16c43) that was making sure that CheckoutLogic does not throw an error when ApolloClient calls success callback twice. New version of ApolloClient does not have that problem so the workaround is not needed anymore
2. Fixed name of id attribute in magento2 api - it's called now `customer_address_id` as magento accepts that one (instead of `id` when sending address from address book)

**What is the current behavior? (You can also link to an open issue here)**
See #399.

**What is the new behavior (if this is a feature change)?**
The problem is removed - user can now correctly use address from his address book.

