### PR TITLE
CategoryLayout with noFilters variant

### DIFF
--- a/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
@@ -44,7 +44,7 @@ const CategoryPage = ({ id }) => (
           const filtersData = getFiltersData(state.filters, aggregations);
 
           return (
-            <CategoryLayout>
+            <CategoryLayout variant={!filtersData.length && 'noFilters'}>
               {loading && <Loader variant="overlay" />}
               <Box gridArea={CategoryArea.heading}>
                 <H1>{name}</H1>
@@ -56,29 +56,31 @@ const CategoryPage = ({ id }) => (
                 </FlexLayout>
                 <Divider mt="xs" />
               </Box>
-              <Box gridArea={CategoryArea.filters}>
-                <Responsive width="md">
-                  {matches =>
-                    matches ? (
-                      <Filters data={filtersData} />
-                    ) : (
-                      <Toggle initial={false}>
-                        {({ on, toggle }) => (
-                          <React.Fragment>
-                            <Button onClick={toggle}>Filters</Button>
-                            <Sidebar isOpen={on} side="left" close={toggle}>
-                              <GridLayout gridRowGap="md">
-                                <H3 ml="xl">Filters</H3>
-                                <Filters data={filtersData} px="md" />
-                              </GridLayout>
-                            </Sidebar>
-                          </React.Fragment>
-                        )}
-                      </Toggle>
-                    )
-                  }
-                </Responsive>
-              </Box>
+              {filtersData.length && (
+                <Box gridArea={CategoryArea.filters}>
+                  <Responsive width="md">
+                    {matches =>
+                      matches ? (
+                        <Filters data={filtersData} />
+                      ) : (
+                        <Toggle initial={false}>
+                          {({ on, toggle }) => (
+                            <React.Fragment>
+                              <Button onClick={toggle}>Filters</Button>
+                              <Sidebar isOpen={on} side="left" close={toggle}>
+                                <GridLayout gridRowGap="md">
+                                  <H3 ml="xl">Filters</H3>
+                                  <Filters data={filtersData} px="md" />
+                                </GridLayout>
+                              </Sidebar>
+                            </React.Fragment>
+                          )}
+                        </Toggle>
+                      )
+                    }
+                  </Responsive>
+                </Box>
+              )}
               <Box gridArea={CategoryArea.content}>
                 <FiltersSummary data={filtersData} />
                 <ProductsList products={items} />

--- a/packages/falcon-ecommerce-uikit/src/Category/CategoryLayout.tsx
+++ b/packages/falcon-ecommerce-uikit/src/Category/CategoryLayout.tsx
@@ -41,6 +41,18 @@ export const CategoryLayout = themed({
       },
       css: {
         position: 'relative'
+      },
+
+      variants: {
+        noFilters: {
+          // prettier-ignore
+          gridTemplate: toGridTemplate([
+              ['1fr'],
+              [CategoryArea.heading],
+              [CategoryArea.content],
+              [CategoryArea.footer]
+            ])
+        }
       }
     }
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix

**What is the current behavior? (You can also link to an open issue here)**
when our backend does not return Filters for Category (which is rather rare) we display  blank filter aside next to 

**What is the new behavior (if this is a feature change)?**
when there are no filters then we expand ProductList into entire available width (no more blank filter aside)

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No
