### PR TITLE
Fix signup for magento 2.2

### DIFF
--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -1105,20 +1105,15 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * @param {string} input.firstname - customer first name
    * @param {String} input.lastname - customer last name
    * @param {String} input.password - customer password
-   * @param {string|number} input.cart.quoteId - cart id
    * @return {Promise<Customer>} - new customer data
    */
   async signUp(obj, { input }) {
     const { email, firstname, lastname, password, autoSignIn } = input;
-    const { cart: { quoteId = null } = {} } = this.session;
     const customerData = {
       customer: {
         email,
         firstname,
-        lastname,
-        extension_attributes: {
-          guest_quote_id: quoteId
-        }
+        lastname
       },
       password
     };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
`extension_attributes` have been removed from sign-up request as that parameter is not supported anymore by this endpoint (we now use separate api for cart merging which is automatically executed when user signs in).

**What is the current behavior? (You can also link to an open issue here)**
Api client sends `extension_attributes` and it causes error in Magento

**What is the new behavior (if this is a feature change)?**
Parameter has been removed - sign up works correctly