### PR TITLE
Product thumbnail fix

### DIFF
--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -589,6 +589,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
       currency,
       name: htmlHelpers.stripHtml(data.name),
       description: customAttributes.description,
+      thumbnail: data.image,
       gallery: resolveGallery(data),
       seo: {
         title: customAttributes.metaTitle,

--- a/packages/falcon-magento2-api/src/index.test.js
+++ b/packages/falcon-magento2-api/src/index.test.js
@@ -218,6 +218,25 @@ describe('Magento2Api', () => {
     });
   });
 
+  describe('reduceProduct()', () => {
+    it('should properly resolve thumbnail when only "image" property is passed', async () => {
+      const result = api.reduceProduct({
+        price: {
+          regular_price: 49,
+          special_price: null,
+          min_tier_price: null
+        },
+        sku: 'WSH11',
+        name: 'Ina Compression Short',
+        image: 'path/to/image.jpg',
+        type_id: 'configurable',
+        is_salable: 1,
+        url_path: 'ina-compression-short.html'
+      });
+      expect(result.thumbnail).toEqual('path/to/image.jpg');
+    });
+  });
+
   it('breadcrumbs resolver should call proper endpoint with proper url without leading slash', async () => {
     nock(URL)
       .get(createMagentoUrl('/falcon/breadcrumbs?url=sample-product.html'))


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Use `image` property for `thumbnail` field on listing pages when there are no `extension_attributes` passed.

**What is the current behavior? (You can also link to an open issue here)**
`thumbnail` is not set when `extension_attributes` field is not passed

**What is the new behavior (if this is a feature change)?**
As above.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

**Other information:**
-