### PR TITLE
Add typename for Apollo Client

### DIFF
--- a/packages/falcon-client/docs/ANALYTICS.md
+++ b/packages/falcon-client/docs/ANALYTICS.md
@@ -32,6 +32,7 @@ You configuration source must provide the following data:
 ```json
 {
   "googleAnalytics": {
+    "__typename": "ConfigGoogleAnalytics",
     "trackerID": "UA-xxxxx"
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds typename for GraphQL

**What is the current behavior? (You can also link to an open issue here)**
```
Missing field __typename in {
  "trackerID": "UA-XXXXXXXX"
}
```

Falcon gives this error in the client when this line doesn't exist. Apollo Client needs it.

**What is the new behavior (if this is a feature change)?**
No error, track pageviews correct

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

**Other information:**
