### PR TITLE
Use category's id from filters list when querying

### DIFF
--- a/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
@@ -23,14 +23,24 @@ import { Filters } from './Filters';
 
 const copy = item => item && JSON.parse(JSON.stringify(item));
 
+// if product's category is in filters, use that as a value for categoryId parameter of CategoryProductsQuery
+const getId = (id, filters) => {
+  let resultId = id;
+  const category = filters.find(item => item.field === 'cat');
+  if (category && category.value) {
+    resultId = Array.isArray(category.value) && category.value.length > 0 ? category.value[0] : category.value;
+  }
+  return resultId;
+};
+
 const CategoryPage = ({ id }) => (
   <SearchConsumer>
     {({ state }) => (
       <CategoryProductsQuery
         variables={{
-          categoryId: id,
+          categoryId: getId(id, state.filters),
           sort: state.sort,
-          filters: copy(state.filters)
+          filters: copy(state.filters).filter(item => item.field !== 'cat')
         }}
         passLoading
       >


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
It fixes the bug described in this [issue](https://github.com/deity-io/falcon/issues/426).

**What is the current behavior? (You can also link to an open issue here)**
If you select Men or Women from the Header and then click on any filter in Category list, you will get 0 results, even though in filters it shows that it has products.
