### PR TITLE
Improving the way how Falcon extracts root fields from partial extension GQL schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 
 - added support of ComponentContainer ([#515](https://github.com/deity-io/falcon/pull/515))
 - added auto-installing of Subscription handlers ([#520](https://github.com/deity-io/falcon/pull/520))
+- improved the way of extracting root fields for partial extension schemas ([#541](https://github.com/deity-io/falcon/pull/541))
 
 ## Falcon v1.2 (2019-06-26)
 

--- a/packages/falcon-server-env/src/models/Extension.ts
+++ b/packages/falcon-server-env/src/models/Extension.ts
@@ -1,5 +1,4 @@
-import { GraphQLResolveInfo, GraphQLSchema, GraphQLObjectType } from 'graphql';
-import { makeExecutableSchema } from 'graphql-tools';
+import { DocumentNode, GraphQLResolveInfo, parse } from 'graphql';
 import { EventEmitter2 } from 'eventemitter2';
 import Logger, { Logger as LoggerType } from '@deity/falcon-logger';
 import {
@@ -66,13 +65,15 @@ export abstract class Extension {
   /**
    * GraphQL configuration getter
    * @param {string|Array<string>} typeDefs Extension's GQL schema type definitions
-   * @returns {Object} GraphQL configuration object
+   * @returns {object} GraphQL configuration object
    */
   async getGraphQLConfig(typeDefs: string | Array<string> = ''): Promise<GraphQLConfig> {
     if (!typeDefs) {
       this.logger.warn(`typeDefs is empty! Make sure you call "super.getGraphQLConfig(typeDefs)" properly`);
     }
-    const rootTypes: RootFieldTypes = this.getRootTypeFields(typeDefs);
+    const rootTypes: RootFieldTypes = await this.logger.traceTime(`Processing schema fields`, () =>
+      Promise.resolve(this.getRootTypeFields(typeDefs))
+    );
     const resolvers: GraphQLResolverMap = {};
 
     Object.keys(rootTypes).forEach((typeName: string) => {
@@ -114,7 +115,7 @@ export abstract class Extension {
   /**
    * Returns a session object from the assigned API Provider
    * @param {GraphQLContext} context GraphQL Resolver context object
-   * @returns {Object} Session object
+   * @returns {object} Session object
    */
   getApiSession(context: GraphQLContext): any {
     return this.getApi(context)!.session;
@@ -156,44 +157,34 @@ export abstract class Extension {
    * @returns {RootFieldTypes} Map of GQL type-fields
    */
   protected getRootTypeFields(typeDefs: string | Array<string>): RootFieldTypes {
-    const result: RootFieldTypes = {};
+    const result: RootFieldTypes = {
+      Query: [],
+      Mutation: []
+    };
     if (!typeDefs) {
       return result;
     }
     try {
-      const executableSchema: GraphQLSchema = makeExecutableSchema({
-        typeDefs: [
-          Array.isArray(typeDefs)
-            ? typeDefs.join('\n')
-            : typeDefs
-                // Removing "extend type X" to avoid "X type missing" errors
-                .replace(/extend\s+type/gm, 'type')
-                // Removing directives and their definitions
-                .replace(/(directive @(.*))/gm, '')
-                .replace(/@(.*[^{\n])/gm, '')
-                // Removing type references from the base schema types
-                .replace(/:\s*(\w+)/gm, ': Int')
-                .replace(/\[\s*(\w+)\s*]/gm, '[Int]')
-        ],
-        resolverValidationOptions: {
-          requireResolversForResolveType: false
+      const docNode: DocumentNode = parse(Array.isArray(typeDefs) ? typeDefs.join('\n') : typeDefs);
+      docNode.definitions.forEach(definition => {
+        if (definition.kind !== 'ObjectTypeDefinition' && definition.kind !== 'ObjectTypeExtension') {
+          return;
         }
-      });
 
-      [executableSchema.getQueryType(), executableSchema.getMutationType()].forEach(
-        (type: GraphQLObjectType | undefined | null) => {
-          if (!type) {
-            return;
-          }
-          const typeName: string = (type as GraphQLObjectType).name;
-          Object.keys((type as GraphQLObjectType).getFields()).forEach((field: string) => {
-            if (!(typeName in result)) {
-              result[typeName] = [];
+        const typeName: string = definition.name.value;
+        if (!['Query', 'Mutation'].includes(typeName)) {
+          return;
+        }
+
+        if (definition.fields) {
+          definition.fields.forEach(field => {
+            const fieldName = field.name.value;
+            if (!result[typeName].includes(fieldName)) {
+              result[typeName].push(fieldName);
             }
-            result[typeName].push(field as string);
           });
         }
-      );
+      });
     } catch (error) {
       error.message = `${this.name}: Failed to get root type fields - ${error.message}`;
       throw error;

--- a/packages/falcon-server-env/src/models/Extension.ts
+++ b/packages/falcon-server-env/src/models/Extension.ts
@@ -77,6 +77,9 @@ export abstract class Extension {
     const resolvers: GraphQLResolverMap = {};
 
     Object.keys(rootTypes).forEach((typeName: string) => {
+      if (!rootTypes[typeName].length) {
+        return;
+      }
       resolvers[typeName] = {};
       rootTypes[typeName].forEach((fieldName: string) => {
         this.logger.debug(

--- a/packages/falcon-server-env/src/models/Extension.ts
+++ b/packages/falcon-server-env/src/models/Extension.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, GraphQLResolveInfo, parse } from 'graphql';
+import { DocumentNode, Kind, GraphQLResolveInfo, parse } from 'graphql';
 import { EventEmitter2 } from 'eventemitter2';
 import Logger, { Logger as LoggerType } from '@deity/falcon-logger';
 import {
@@ -170,7 +170,7 @@ export abstract class Extension {
     try {
       const docNode: DocumentNode = parse(Array.isArray(typeDefs) ? typeDefs.join('\n') : typeDefs);
       docNode.definitions.forEach(definition => {
-        if (definition.kind !== 'ObjectTypeDefinition' && definition.kind !== 'ObjectTypeExtension') {
+        if (definition.kind !== Kind.OBJECT_TYPE_DEFINITION && definition.kind !== Kind.OBJECT_TYPE_EXTENSION) {
           return;
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
Improvement. Getting rid of partially working RegExp patterns, parsing partial schemas using native `graphql` parse method without making such schemas "executable".

### What is the current behavior?
Currently, it only works in certain conditions (multiline directives not fully supported by these RegExp patterns).

### What is the new behavior?
Fully featured support of GraphQL syntax without a need to support RegExp patterns.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Fully backward compatible, no changes required (it's an internal change)

### Other information
According to trace logs - improved the speed of parsing the root fields (about 2 times faster now).