### PR TITLE
Adding TTL for cache tags

### DIFF
--- a/packages/falcon-server-env/src/cache/Cache.ts
+++ b/packages/falcon-server-env/src/cache/Cache.ts
@@ -26,8 +26,7 @@ export type GetCacheOptions = {
   options?: SetCacheOptions;
 };
 
-// 1 hour
-const DEFAULT_TAG_TTL: number = 60 * 60;
+const DEFAULT_TAG_TTL: number = 60 * 60; // 1 hour
 
 /**
  * Cache-wrapper with extended methods

--- a/packages/falcon-server-env/src/cache/Cache.ts
+++ b/packages/falcon-server-env/src/cache/Cache.ts
@@ -26,11 +26,14 @@ export type GetCacheOptions = {
   options?: SetCacheOptions;
 };
 
+// 1 hour
+const DEFAULT_TAG_TTL: number = 60 * 60;
+
 /**
  * Cache-wrapper with extended methods
  */
 export default class Cache<V = any> implements KeyValueCache<V> {
-  constructor(private cacheProvider: KeyValueCache<string>) {}
+  constructor(protected cacheProvider: KeyValueCache<string>, protected tagTtl: number = DEFAULT_TAG_TTL) {}
 
   async get(key: string): Promise<V>;
 
@@ -164,7 +167,7 @@ export default class Cache<V = any> implements KeyValueCache<V> {
         if (typeof tagValue === 'undefined' && createIfMissing) {
           // For "createIfMissing" flag - generate new tag value and save it to the cache
           tagValue = this.generateTagValue();
-          await this.set(tag, tagValue);
+          await this.set(tag, tagValue, { ttl: this.tagTtl });
         }
 
         if (tagValue) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
When using Redis/Memcached as a cache backend and setting value without a TTL option - Apollo forces `300` seconds (5 min) TTL by default (meaning - there's no way to set a cached value without an expiration):

- https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-cache-redis/src/RedisCache.ts#L8
- https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-cache-memcached/src/index.ts#L9

**What is the new behavior (if this is a feature change)?**
Setting 1 hour TTL for cache tags.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No
