### PR TITLE
Cache async calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) are already released and available via npm. Versions without a date are not released yet.
 
+## Falcon vNext
+
+### Falcon Server vNext
+
+- improved Cache calls by tracking simultaneous requests with the same cache-key ([#557](https://github.com/deity-io/falcon/pull/557))
+
+### Falcon Server Env vNext
+
+- added optional `ApiDataSource.getExtraResolvers` static method to define extra resolvers ([#557](https://github.com/deity-io/falcon/pull/557))
+
 ## Falcon v1.3 (2019-08-01)
 
 - required changes were made to make Falcon compatible with Node v12 ([#537](https://github.com/deity-io/falcon/pull/537))

--- a/packages/falcon-magento2-api/src/index.js
+++ b/packages/falcon-magento2-api/src/index.js
@@ -7,7 +7,6 @@ const has = require('lodash/has');
 const forEach = require('lodash/forEach');
 const isPlainObject = require('lodash/isPlainObject');
 const addMinutes = require('date-fns/add_minutes');
-const { addResolveFunctionsToSchema } = require('graphql-tools');
 const { ApiUrlPriority, htmlHelpers } = require('@deity/falcon-server-env');
 const { Magento2ApiBase } = require('./Magento2ApiBase');
 const { tryParseNumber } = require('./utils/number');
@@ -25,43 +24,36 @@ const FALCON_CART_ACTIONS = [
  * API for Magento2 store - provides resolvers for shop schema.
  */
 module.exports = class Magento2Api extends Magento2ApiBase {
-  constructor(params) {
-    super(params);
-    this.addTypeResolvers();
-  }
-
   /**
    * Adds additional resolve functions to the stitched GQL schema for the sake of data-splitting
    */
-  async addTypeResolvers() {
-    const resolvers = {
+  static getExtraResolvers(apiGetter) {
+    return {
       BackendConfig: {
-        shop: () => this.fetchBackendConfig()
+        shop: apiGetter(api => api.fetchBackendConfig())
       },
       ShopConfig: {
-        stores: () => this.getActiveStores(),
-        currencies: () => this.getActiveCurrencies(),
-        baseCurrency: () => this.session.baseCurrency,
-        timezone: () => this.session.timezone,
-        weightUnit: () => this.session.weightUnit
+        stores: apiGetter(api => api.getActiveStores()),
+        currencies: apiGetter(api => api.getActiveCurrencies()),
+        baseCurrency: apiGetter(api => api.session.baseCurrency),
+        timezone: apiGetter(api => api.session.timezone),
+        weightUnit: apiGetter(api => api.session.weightUnit)
       },
       Product: {
-        price: (...args) => this.productPrice(...args),
-        tierPrices: (...args) => this.productTierPrices(...args),
-        configurableOptions: (...x) => this.configurableProductOptions(...x),
-        breadcrumbs: (...args) => this.breadcrumbs(...args)
+        price: apiGetter((api, ...args) => api.productPrice(...args)),
+        tierPrices: apiGetter((api, ...args) => api.productTierPrices(...args)),
+        configurableOptions: apiGetter((api, ...args) => api.configurableProductOptions(...args)),
+        breadcrumbs: apiGetter((api, ...args) => api.breadcrumbs(...args))
       },
       Category: {
-        breadcrumbs: (...args) => this.breadcrumbs(...args),
-        products: (...args) => this.categoryProducts(...args),
-        children: (...args) => this.categoryChildren(...args)
+        breadcrumbs: apiGetter((api, ...args) => api.breadcrumbs(...args)),
+        products: apiGetter((api, ...args) => api.categoryProducts(...args)),
+        children: apiGetter((api, ...args) => api.categoryChildren(...args))
       },
       PaymentMethod: {
-        config: (...args) => this.getPaymentMethodConfig(...args)
+        config: apiGetter((api, ...args) => api.getPaymentMethodConfig(...args))
       }
     };
-    this.logger.debug(`Adding additional resolve functions`);
-    addResolveFunctionsToSchema({ schema: this.gqlServerConfig.schema, resolvers });
   }
 
   async getActiveStores() {
@@ -111,7 +103,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetch category data
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {number} id id of the requested category
    * @returns {Promise<Category>} - converted response with category data
    */
@@ -122,8 +114,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetch products for fetched category
-   * @param {Object} obj fetched category
-   * @param {Object} params query params
+   * @param {object} obj fetched category
+   * @param {object} params query params
    * @returns {Promise<ProductList>} - fetched list of products
    */
   async categoryProducts(obj, params) {
@@ -173,7 +165,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Process category data from Magento2 response
-   * @param {Object} data categoryObject from Magento2 backend
+   * @param {object} data categoryObject from Magento2 backend
    * @returns {Category} processed response
    */
   convertCategory(data) {
@@ -200,8 +192,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   /**
    * Convert attributes from array of object into flat key-value pair,
    * where key is attribute code and value is attribute value
-   * @param {Object} response response from Magento2 backend
-   * @returns {Object} converted response
+   * @param {object} response response from Magento2 backend
+   * @returns {object} converted response
    */
   convertAttributesSet(response) {
     const { custom_attributes: attributes = [] } = response;
@@ -239,7 +231,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Convert breadcrumbs for category, product entities
-   * @param {Array<Object>} breadcrumbs  array of breadcrumbs entries from Magento
+   * @param {Array<object>} breadcrumbs  array of breadcrumbs entries from Magento
    * @returns {Breadcrumb[]} converted breadcrumbs
    */
   convertBreadcrumbs(breadcrumbs = []) {
@@ -263,8 +255,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Get list of products based on filters from params
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
+   * @param {object} obj Parent object
+   * @param {object} params request params
    * @param {number} params.categoryId id of the category to search in
    * @param {boolean} params.includeSubcategories flag indicates if products from subcategories should be included
    * @param {ShopPageQuery} params.query definitions of aggregations
@@ -306,8 +298,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Converts passed params to format acceptable by Magento
-   * @param {Object} params parameters passed to the resolver
-   * @returns {Object} params converted to format acceptable by Magento
+   * @param {object} params parameters passed to the resolver
+   * @returns {object} params converted to format acceptable by Magento
    */
   createSearchParams(params) {
     const { filters = [], pagination, sort = {} } = params;
@@ -341,11 +333,11 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Include field to list of filters. Used when making request to listing endpoint.
-   * @param {Object} params request params that should be populated with filters
+   * @param {object} params request params that should be populated with filters
    * @param {string} field filter field to include
    * @param {string} value field value
    * @param {string} operator condition type of the filter
-   * @returns {Object} - request params with additional filter
+   * @returns {object} - request params with additional filter
    */
   addSearchFilter(params = {}, field, value, operator = 'eq') {
     params.filterGroups = isEmpty(params.filterGroups) ? [] : params.filterGroups;
@@ -361,7 +353,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * @param {string} field field name
    * @param {string|Array<string>} value value of the field
    * @param {FilterOperator} operator filter operator
-   * @returns {Object} Magento-compatible filters definition
+   * @returns {object} Magento-compatible filters definition
    */
   createMagentoFilter(field, value, operator) {
     if (!Array.isArray(value)) {
@@ -436,7 +428,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * @param {string} field field name
    * @param {string} value filter value
    * @param {string} operator filter operator to be used
-   * @returns {Object} Magento filter
+   * @returns {object} Magento filter
    */
   createSimpleFilter(field, value, operator) {
     return {
@@ -448,7 +440,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetch list of the products based on passed criteria
-   * @param {Object} params search criteria
+   * @param {object} params search criteria
    * @returns {Promise<Product[]>} - list of product items
    */
   fetchProductList(params = {}) {
@@ -475,7 +467,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   /**
    * Check if given filter is set in params
    * @param {string} filterName name of the filter
-   * @param {Object} params params with filters
+   * @param {object} params params with filters
    * @returns {boolean} if filter is set
    */
   isFilterSet(filterName, params = {}) {
@@ -489,13 +481,13 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   /**
    * Generic method for endpoints handling category and product listing
    * @param {string} path path to magento api endpoint
-   * @param {Object} params request params
-   * @param {Array<Object>} [params.filters] filters for the collection
+   * @param {object} params request params
+   * @param {Array<object>} [params.filters] filters for the collection
    * @param {boolean} [params.includeSubcategories] use subcategories in the search flag
-   * @param {Object} [params.query] request query params
+   * @param {object} [params.query] request query params
    * @param {number} [params.query.page] pagination page
    * @param {number} [params.query.perPage] number of items per page
-   * @param {Array<Object>} [params.sortOrders] list of sorting parameters
+   * @param {Array<object>} [params.sortOrders] list of sorting parameters
    * @param {string[]} [params.withAttributeFilters] list of attributes for layout navigation
    * @returns {Promise<Product[] | Category[]>} - response from endpoint
    */
@@ -533,9 +525,9 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Process data from listing endpoint
-   * @param {Object} response response from Magento2 backend
+   * @param {object} response response from Magento2 backend
    * @param {string} currency selected currency
-   * @returns {Object} - processed response
+   * @returns {object} - processed response
    */
   convertList(response = {}, currency = null) {
     const { items = [], custom_attributes: attributes } = response;
@@ -561,7 +553,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Reduce product data to what is needed.
-   * @param {Object} data API response from Magento2 backend
+   * @param {object} data API response from Magento2 backend
    * @param {string} currency currency code
    * @returns {Product} reduced data
    */
@@ -628,7 +620,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Resolve Product Price from Product
-   * @param {Object} parent parent (MagentoProduct or MagentoProductListItem)
+   * @param {object} parent parent (MagentoProduct or MagentoProductListItem)
    * @returns {ProductPrice} product price
    */
   productPrice(parent) {
@@ -643,10 +635,10 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Resolve Product Tier Price from Product
-   * @param {Object} parent parent (MagentoProduct or MagentoProductListItem)
-   * @param {Object} args arguments
-   * @param {Object} context context
-   * @param {Object} info info
+   * @param {object} parent parent (MagentoProduct or MagentoProductListItem)
+   * @param {object} args arguments
+   * @param {object} context context
+   * @param {object} info info
    * @returns {TierPrice[]} product price
    */
   async productTierPrices(parent, args, context, info) {
@@ -667,10 +659,10 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Resolve Configurable Product Options from Product
-   * @param {Object} parent parent (MagentoProduct or MagentoProductListItem)
-   * @param {Object} args arguments
-   * @param {Object} context context
-   * @param {Object} info info
+   * @param {object} parent parent (MagentoProduct or MagentoProductListItem)
+   * @param {object} args arguments
+   * @param {object} context context
+   * @param {object} info info
    * @returns {ConfigurableProductOption} configurable product options
    */
   async configurableProductOptions(parent, args, context, info) {
@@ -710,8 +702,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Special endpoint to fetch any magento entity by it's url, for example product, cms page
-   * @param {Object} _ Parent object
-   * @param {Object} params request params
+   * @param {object} _ Parent object
+   * @param {object} params request params
    * @param {string} [params.path] request path to be checked against api urls
    * @param {boolean} [params.loadEntityData] flag to mark whether endpoint should return entity data as well
    * @returns {Promise} - request promise
@@ -736,7 +728,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Search for product with id
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {string} id product id called by magento entity_id
    * @returns {Promise<Product>} product data
    */
@@ -755,8 +747,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Add product to cart
-   * @param {Object} obj Parent object
-   * @param {Object} input product data
+   * @param {object} obj Parent object
+   * @param {object} input product data
    * @param {string} input.sku added product sku
    * @param {number} input.qty added product qty
    * @returns {Promise<CartItemPayload>} - cart item data
@@ -820,7 +812,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   /**
    * Merges guest cart with the cart of the signed in user
    * @param {string} guestQuoteId masked id of guest cart
-   * @returns {Object} - new cart data
+   * @returns {object} - new cart data
    */
   async mergeGuestCart(guestQuoteId) {
     // send masked_quote_id as param so Magento merges guest's cart with user's cart
@@ -833,7 +825,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   /**
    * Ensure customer has cart in the session.
    * Creates cart if it doesn't yet exist.
-   * @returns {Object} - new cart data
+   * @returns {object} - new cart data
    */
   async ensureCart() {
     const { cart } = this.session;
@@ -866,9 +858,9 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Make sure price fields are float
-   * @param {Object} data object to process
+   * @param {object} data object to process
    * @param {string[]} fieldsToProcess array with field names
-   * @returns {Object} updated object
+   * @returns {object} updated object
    */
   processPrice(data = {}, fieldsToProcess = []) {
     fieldsToProcess.forEach(field => {
@@ -913,8 +905,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Process and merge cart and totals response
-   * @param {Object} quoteData data from cart endpoint
-   * @param {Object} totalsData data from cart totals endpoint
+   * @param {object} quoteData data from cart endpoint
+   * @param {object} totalsData data from cart totals endpoint
    * @returns {Cart} object with merged data
    */
   convertCartData(quoteData, totalsData) {
@@ -982,7 +974,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Make request for customer token
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {SignIn} input form data
    * @param {string} input.email user email
    * @param {string} input.password user password
@@ -1050,7 +1042,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Create customer account
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {SignUp} input registration form data
    * @param {string} input.email customer email
    * @param {string} input.firstname customer first name
@@ -1115,7 +1107,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Converts address response from magento to Address type
-   * @param {Object} response api response
+   * @param {object} response api response
    * @returns {Address} parsed address
    */
   convertAddressData(response) {
@@ -1138,9 +1130,9 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetch collection of customer orders
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
-   * @param {Object} params.query request query params
+   * @param {object} obj Parent object
+   * @param {object} params request params
+   * @param {object} params.query request query params
    * @param {number} params.query.page pagination page
    * @param {number} params.query.perPage number of items per page
    * @returns {Orders} parsed orders with pagination info
@@ -1161,8 +1153,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetch info about customer order based on order id
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
+   * @param {object} obj Parent object
+   * @param {object} params request params
    * @param {number} params.id order id
    * @returns {Promise<Order>} - order info
    */
@@ -1181,7 +1173,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Process customer order data
-   * @param {Object} response response from Magento2 backend
+   * @param {object} response response from Magento2 backend
    * @returns {Order} processed order
    */
   convertOrder(response) {
@@ -1210,7 +1202,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Update magento items collection response
-   * @param {Array<Object>} response products bought
+   * @param {Array<object>} response products bought
    * @returns {OrderItem[]} converted items
    */
   convertItemsResponse(response = []) {
@@ -1232,8 +1224,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Process cart totals data
-   * @param {Object} response totals response from Magento2 backend
-   * @returns {Object} processed response
+   * @param {object} response totals response from Magento2 backend
+   * @returns {object} processed response
    */
   convertTotals(response) {
     let totalsData = response;
@@ -1258,7 +1250,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Update items in cart
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {UpdateCartItemInput} input cart item data
    * @param {string} input.sku item sku
    * @param {number} input.qty item qty
@@ -1294,7 +1286,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Remove item from cart
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {RemoveCartItemInput} input cart item data
    * @param {string} input.itemId item id
    * @returns {Promise<RemoveCartItemResponse>} RemoveCartItemResponse with itemId when operation was successful
@@ -1320,7 +1312,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Updates customer profile data
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {CustomerInput} data data to be saved
    * @returns {Promise<Customer>} updated customer data
    */
@@ -1332,8 +1324,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Request customer address
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
+   * @param {object} obj Parent object
+   * @param {object} params request params
    * @param {number} params.id address id
    * @returns {Promise<Address>} requested address data
    */
@@ -1356,7 +1348,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Add new customer address
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {AddressInput} data address data
    * @returns {Promise<Address>} added address data
    */
@@ -1368,7 +1360,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Change customer address data
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {AddressInput} data data to change
    * @returns {Promise<Address>} updated address data
    */
@@ -1380,8 +1372,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Remove customer address data
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
+   * @param {object} obj Parent object
+   * @param {object} params request params
    * @param {number} params.id address id
    * @returns {boolean} true when removed successfully
    */
@@ -1391,8 +1383,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Check if given password reset token is valid
-   * @param {Object} obj Parent object
-   * @param {Object} params request params
+   * @param {object} obj Parent object
+   * @param {object} params request params
    * @param {string} params.token reset password token
    * @returns {Promise<boolean>} true if token is valid
    */
@@ -1412,7 +1404,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Generate customer password reset token
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {EmailInput} input request params
    * @param {string} input.email user email
    * @returns {Promise<boolean>} always true to avoid spying for registered emails
@@ -1425,7 +1417,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Reset customer password using provided reset token
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {CustomerPasswordReset} input request params
    * @param {string} input.customerId customer email
    * @param {string} input.resetToken reset token
@@ -1439,7 +1431,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Change customer password
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {CustomerPasswordReset} input request params
    * @param {string} input.password new password
    * @param {string} input.currentPassword current password
@@ -1465,7 +1457,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Apply coupon to cart
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {CouponInput} input request data
    * @param {string} [input.couponCode] coupon code
    * @returns {Promise<boolean>} true on success
@@ -1546,8 +1538,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
    * Make a call to cart related endpoint
    * @param {string} path path to magento api endpoint
    * @param {string} method request method
-   * @param {Object} data request data
-   * @returns {Promise<Object>} response data
+   * @param {object} data request data
+   * @returns {Promise<object>} response data
    */
   async performCartAction(path, method, data) {
     const { cart } = this.session;
@@ -1576,7 +1568,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Sets shipping method for the order
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {ShippingInput} input shipping configuration
    * @returns {Promise<ShippingInformation>} shipping configuration info
    */
@@ -1599,9 +1591,9 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Sets payment method for the current cart
-   * @param {Object} obj Root object
+   * @param {object} obj Root object
    * @param {PlaceOrderInput} input Payment info payload
-   * @returns {Object} Result
+   * @returns {object} Result
    */
   async setPaymentInfo(obj, { input }) {
     const address = this.prepareAddressForOrder(input.billingAddress);
@@ -1617,7 +1609,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Place order
-   * @param {Object} obj Parent object
+   * @param {object} obj Parent object
    * @param {PlaceOrderInput} input form data
    * @returns {Promise<PlaceOrderResult>} order data
    */
@@ -1657,8 +1649,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Handling Adyen 3D-secure payment
-   * @param {Object} adyenCcResult adyenRedirect data
-   * @returns {Object} Redirect response data
+   * @param {object} adyenCcResult adyenRedirect data
+   * @returns {object} Redirect response data
    */
   handleAdyen3dSecure(adyenCcResult) {
     const { origin } = this.context.headers;
@@ -1698,8 +1690,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Handling PayPal payment on its own page
-   * @param {Object} input Order payload
-   * @returns {Object} PayPal response data
+   * @param {object} input Order payload
+   * @returns {object} PayPal response data
    */
   async handlePayPalToken(input) {
     const { origin } = this.context.headers;
@@ -1763,8 +1755,8 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetches breadcrumbs for passed path
-   * @param {Object} obj parent
-   * @param {Object} params parameters passed to the resolver
+   * @param {object} obj parent
+   * @param {object} params parameters passed to the resolver
    * @returns {Promise<[Breadcrumb]>} breadcrumbs fetched from backend
    */
   async breadcrumbs(obj, { path }) {
@@ -1774,7 +1766,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Fetches subcategories of fetched category
-   * @param {Object} obj parent object
+   * @param {object} obj parent object
    * @returns {Promise<[Category]>} fetched subcategories
    */
   async categoryChildren(obj) {
@@ -1785,7 +1777,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
 
   /**
    * Convert raw aggregations from Magento to proper format
-   * @param {[Object]} rawAggregations raw aggregations data
+   * @param {[object]} rawAggregations raw aggregations data
    * @returns {[Aggregation]} - processed aggregations
    */
   processAggregations(rawAggregations = []) {

--- a/packages/falcon-server-env/src/models/ApiDataSource.test.ts
+++ b/packages/falcon-server-env/src/models/ApiDataSource.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, import/no-extraneous-dependencies */
 import 'jest-extended';
-import { ApiDataSource } from './ApiDataSource';
 import { ContextRequestOptions, ContextData, ContextFetchRequest, ContextFetchResponse } from '../types';
+import { ApiDataSource } from './ApiDataSource';
 
 import nock = require('nock');
 
@@ -249,7 +249,7 @@ describe('ApiDataSource', () => {
       );
     });
 
-    it('Should skip "memoizedResults" map for GET requests', async () => {
+    it('Should not skip "memoizedResults" map for GET requests', async () => {
       const customApi: CustomApiDataSource = new CustomApiDataSource({
         config: { protocol: 'http', host: 'example.com' }
       });
@@ -259,7 +259,7 @@ describe('ApiDataSource', () => {
       await customApi.getInfo();
       expect(didReceiveResponseSpy).toHaveBeenCalledTimes(1);
       await customApi.getInfo();
-      expect(didReceiveResponseSpy).toHaveBeenCalledTimes(2);
+      expect(didReceiveResponseSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/falcon-server-env/src/models/ApiDataSource.ts
+++ b/packages/falcon-server-env/src/models/ApiDataSource.ts
@@ -128,8 +128,8 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
   /**
    * Should be implemented if ApiDataSource wants to deliver content via dynamic URLs.
    * It should return priority value for passed url.
-   * @param url - url for which the priority should be returned
-   * @return {number} Priority index
+   * @param url url for which the priority should be returned
+   * @returns {number} Priority index
    */
   getFetchUrlPriority?(url: string): number;
 
@@ -139,6 +139,8 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
     context: TContext,
     info: GraphQLResolveInfo
   ): Promise<FetchUrlResult>;
+
+  static getExtraResolvers?(apiGetter: () => ApiDataSource): object;
 
   /**
    * Optional method to get a cache context object which should contain a distinguish data
@@ -164,7 +166,7 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
   /**
    * Hook that is going to be executed for every REST request if authorization is required
    * @param {ContextRequestOptions} request request
-   * @return {Promise<void>} promise
+   * @returns {Promise<void>} promise
    */
   async authorizeRequest?(req: ContextRequestOptions): Promise<void>;
 
@@ -240,14 +242,6 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
     return result;
   }
 
-  protected cacheKeyFor(request: Request): string {
-    const cacheKey: string = super.cacheKeyFor(request);
-    // Note: temporary disabling "memoized" map due to issues with GraphQL resolvers,
-    // GET-requests in particular ("fetchUrl" query)
-    this.memoizedResults.delete(cacheKey);
-    return cacheKey;
-  }
-
   private ensureContextPassed(init?: ContextRequestInit): ContextRequestInit {
     const processedInit: ContextRequestInit = init || {};
 
@@ -267,8 +261,8 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
   /**
    * This is a temporary solution to override Apollo's own "trace" method to use external Logger
    * @param {string} label Trace label
-   * @param {function} fn Callback to trace
-   * @return {Promise<TResult>} Result
+   * @param {Function} fn Callback to trace
+   * @returns {Promise<TResult>} Result
    */
   /* istanbul ignore next Skipping code coverage for "dev" function */
   private async traceLog<TResult>(label: string, fn: () => Promise<TResult>): Promise<TResult> {

--- a/packages/falcon-server-env/src/models/ApiDataSource.ts
+++ b/packages/falcon-server-env/src/models/ApiDataSource.ts
@@ -27,6 +27,14 @@ import {
 
 export type PaginationValue = number | string | null;
 
+export type ApiGetter = (
+  api: ApiDataSource,
+  root: any,
+  params: any,
+  context: GraphQLContext,
+  info: GraphQLResolveInfo
+) => any;
+
 export interface GqlServerConfig<TContext = any> {
   schema: GraphQLSchema;
   formatError?: Function;
@@ -140,7 +148,7 @@ export abstract class ApiDataSource<TContext extends GraphQLContext = GraphQLCon
     info: GraphQLResolveInfo
   ): Promise<FetchUrlResult>;
 
-  static getExtraResolvers?(apiGetter: () => ApiDataSource): object;
+  static getExtraResolvers?(apiGetter: ApiGetter): object;
 
   /**
    * Optional method to get a cache context object which should contain a distinguish data

--- a/packages/falcon-server/src/containers/ExtensionContainer.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.js
@@ -31,7 +31,7 @@ module.exports = class ExtensionContainer extends BaseContainer {
 
   /**
    * Instantiates extensions based on passed configuration and registers event handlers for them
-   * @param {Object<string, ExtensionInstanceConfig>} extensions Key-value list of extension configurations
+   * @param {object<string, ExtensionInstanceConfig>} extensions Key-value list of extension configurations
    * @param {Map<string, ApiDataSource>} dataSources Map of API DataSources
    */
   async registerExtensions(extensions, dataSources) {
@@ -70,30 +70,27 @@ module.exports = class ExtensionContainer extends BaseContainer {
 
   /**
    * Initializes each registered extension (in sequence)
-   * @param {Object} obj Parent object
-   * @param {Object} args GQL args
-   * @param {Object} context GQL context
-   * @param {Object} info GQL info
+   * @param {object} obj Parent object
+   * @param {object} args GQL args
+   * @param {object} context GQL context
+   * @param {object} info GQL info
    * @returns {BackendConfig} Merged config
    */
   async fetchBackendConfig(obj, args, context, info) {
-    const configs = [];
-
-    // initialization of extensions cannot be done in parallel because of race condition
-    for (const [extName, ext] of this.extensions) {
-      this.logger.debug(`Fetching "${extName}" API backend config`);
-      const extConfig = await ext.fetchApiBackendConfig(obj, args, context, info);
-      if (extConfig) {
-        configs.push(extConfig);
-      }
-    }
+    // Fetching backend configs async
+    const configs = await Promise.all(
+      Array.from(this.extensions, ([extName, ext]) => {
+        this.logger.debug(`Fetching "${extName}" API backend config`);
+        return ext.fetchApiBackendConfig(obj, args, context, info);
+      })
+    );
 
     return this.mergeConfigs(configs);
   }
 
   /**
    * Merges
-   * @param {Object[]} configs List of API config
+   * @param {object[]} configs List of API config
    * @returns {BackendConfig} Merged config
    */
   mergeConfigs(configs) {
@@ -125,8 +122,8 @@ module.exports = class ExtensionContainer extends BaseContainer {
 
   /**
    * Creates a complete configuration for ApolloServer
-   * @param {Object} defaultConfig default configuration that should be used
-   * @returns {Object} resolved configuration
+   * @param {object} defaultConfig default configuration that should be used
+   * @returns {object} resolved configuration
    */
   async createGraphQLConfig(defaultConfig = {}) {
     const config = Object.assign(
@@ -136,10 +133,7 @@ module.exports = class ExtensionContainer extends BaseContainer {
         // all of them when context will be created. All the results will be merged to produce final context
         contextModifiers: defaultConfig.context ? [defaultConfig.context] : []
       },
-      defaultConfig,
-      {
-        resolvers: defaultConfig.resolvers && !Array.isArray(defaultConfig.resolvers) ? [defaultConfig.resolvers] : []
-      }
+      defaultConfig
     );
 
     for (const [extName, ext] of this.extensions) {

--- a/packages/falcon-server/src/containers/ExtensionContainer.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.js
@@ -129,6 +129,7 @@ module.exports = class ExtensionContainer extends BaseContainer {
     const config = Object.assign(
       {
         schemas: [],
+        resolvers: [],
         // contextModifiers will be used as helpers - it will gather all the context functions and we'll invoke
         // all of them when context will be created. All the results will be merged to produce final context
         contextModifiers: defaultConfig.context ? [defaultConfig.context] : []

--- a/packages/falcon-server/src/containers/ExtensionContainer.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.js
@@ -77,7 +77,6 @@ module.exports = class ExtensionContainer extends BaseContainer {
    * @returns {BackendConfig} Merged config
    */
   async fetchBackendConfig(obj, args, context, info) {
-    // Fetching backend configs async
     const configs = await Promise.all(
       Array.from(this.extensions, ([extName, ext]) => {
         this.logger.debug(`Fetching "${extName}" API backend config`);

--- a/packages/falcon-server/src/containers/ExtensionContainer.test.js
+++ b/packages/falcon-server/src/containers/ExtensionContainer.test.js
@@ -103,7 +103,7 @@ describe('ExtensionContainer', () => {
       }).not.toThrow();
     });
 
-    it('Should produce proper schema from schemas returned by extensions', async () => {
+    it('Should produce proper schema from partial schemas returned by extensions', async () => {
       const query = `
         {
           __type(name: "Product") {

--- a/packages/falcon-server/src/index.js
+++ b/packages/falcon-server/src/index.js
@@ -130,19 +130,22 @@ class FalconServer {
         };
       },
       cache: this.cache,
-      resolvers: {
-        Query: {
-          url: async (...params) => this.dynamicRouteResolver.fetchUrl(...params),
-          backendConfig: async (...params) => this.fetchBackendConfig(...params)
+      resolvers: [
+        {
+          Query: {
+            url: async (...params) => this.dynamicRouteResolver.fetchUrl(...params),
+            backendConfig: async (...params) => this.fetchBackendConfig(...params)
+          },
+          Mutation: {
+            setLocale: (...params) => this.setLocale(...params)
+          },
+          BackendConfig: {
+            activeLocale: (_, __, { session: _session }) => _session.locale
+          },
+          JSON: GraphQLJSON
         },
-        Mutation: {
-          setLocale: (...params) => this.setLocale(...params)
-        },
-        BackendConfig: {
-          activeLocale: (_, __, { session: _session }) => _session.locale
-        },
-        JSON: GraphQLJSON
-      },
+        ...this.apiContainer.resolvers
+      ],
       subscriptions: this.getSubscriptionsOptions(),
       tracing: this.config.debug,
       playground: this.config.debug && {

--- a/packages/falcon-server/src/schemaDirectives/GraphQLCacheInvalidatorDirective.js
+++ b/packages/falcon-server/src/schemaDirectives/GraphQLCacheInvalidatorDirective.js
@@ -35,17 +35,10 @@ module.exports = class GraphQLCacheInvalidatorDirective extends SchemaDirectiveV
    * @returns {void}
    */
   visitFieldDefinition(field) {
-    let { resolve = defaultFieldResolver } = field;
+    const { resolve = defaultFieldResolver } = field;
     const { idPath } = this.args;
 
-    Object.defineProperty(field, 'resolve', {
-      get: () => this.getResolverWithCacheInvalidator(resolve, idPath),
-      // Handling potential "addResolveFunctionsToSchema" calls that define dynamic resolvers
-      set: newResolve => {
-        resolve = newResolve;
-      },
-      configurable: true
-    });
+    field.resolve = this.getResolverWithCacheInvalidator(resolve, idPath);
   }
 
   /**
@@ -79,8 +72,8 @@ module.exports = class GraphQLCacheInvalidatorDirective extends SchemaDirectiveV
    * Invalidate cache from the result using the provided idPath entry
    * @param {mixed} result Resolver result
    * @param {IdPathEntry} idPathEntry ID Path entry
-   * @param {Object} parent GraphQL Resolver parent value
-   * @param {Object} context GraphQL context object
+   * @param {object} parent GraphQL Resolver parent value
+   * @param {object} context GraphQL context object
    * @param {GraphQLResolveInfo} info GraphQL Info object
    * @returns {void}
    */


### PR DESCRIPTION
## The problem

As a part of the investigations to improve the Cache performance in Falcon-Server, there was an issue found with `addResolveFunctionsToSchema` calls during the runtime.

Initially, the issue was causing a problem with the `trace` plugin that hasn't been noticed for a long time (in this case - `magento2-api` package was adding its own additional `breadcrumbs` resolver during the runtime to handle `breadcrumbs` part properly - and therefore overwriting the whole `resolve` function for `breadcrumbs` field that was previously wrapped by the `trace` plugin and other directives):

<img width="1042" alt="Screenshot 2019-09-01 at 22 58 56" src="https://user-images.githubusercontent.com/1118933/64082242-3be9f200-cd0c-11e9-9913-53af39810505.png">

After this fix - the "tracing" panel looks correct (`breadcrumbs` section is in place):

<img width="1144" alt="Screenshot 2019-09-01 at 23 02 15" src="https://user-images.githubusercontent.com/1118933/64082267-a69b2d80-cd0c-11e9-882e-0fdda5fe754b.png">

This find helped us to solve a problem with cache `get` calls (in combination with `set/get` trick in our Cache directives - it led to recursive calls and wouldn't allow us to improve concurrent Cache calls for the same cache-key values).

## Required solution

In order to solve this problem - all the resolvers have to be defined before starting the GQL Server.
Since we don't have access to the configured `apis` (instances of `ApiDataSource`) at the startup stage (they're being instantiated per each request) - I came up with an idea of introducing `getExtraResolvers` static method for `ApiDataSource` base class to fetch such resolvers when Falcon-Server checks the app configuration and generates GQL Server configuration.
Forasmuch as `getExtraResolvers` is a static method, we can only define resolvers without access to the actual instance of a class through this static method (tech details are described below in "Example of migration" section).

This gives us a few benefits:

- We don't alter the Schema multiple times during the runtime
- It enables all the plugins/directives work "normally" without any tricks for "dynamic" changes
- Removes a requirement to have `graphql-tools` package to be installed as your dependency

## General overview

- Changed the way of how extra resolvers are being defined (only once on the app startup) - this is caused by a bug with apollo+graphql (when we call `addResolveFunctionsToSchema` dynamically - they override previously defined/assigned directives)
- Introduced cache get calls tracking (when requesting the same cache key multiple times async - only 1 request will be executed)
- Introduced new optional `getExtraResolvers` static method to get extra resolvers from the configured API
- We no longer clean `memoizedResults` for REST GET requests (improves parallel resolvers to the same URL)
- Side improvement - now we perform backend config fetch in parallel (it will return the result X times faster, X - number of APIs defined)
- It frees a developer from importing `addResolveFunctionsToSchema` function and knowing the exact syntax. The proposed change only expects to get an object of resolvers in result.

## Example of migration

Before:

```javascript
  addTypeResolvers() {
    const resolvers = {
      BackendConfig: {
        shop: () => this.fetchBackendConfig()
      },
      ShopConfig: {
        weightUnit: () => this.session.weightUnit
      },
      Product: {
        price: (...args) => this.productPrice(...args)
      }
    };
    addResolveFunctionsToSchema({ schema: this.gqlServerConfig.schema, resolvers });
  }
```

After:

```javascript
  static getExtraResolvers(apiGetter) {
    return {
      BackendConfig: {
        shop: apiGetter(api => api.fetchBackendConfig())
      },
      ShopConfig: {
        weightUnit: apiGetter(api => api.session.weightUnit)
      },
      Product: {
        price: apiGetter((api, ...args) => api.productPrice(...args))
      }
    };
  }
```

`apiGetter` is a simple callback function that extracts the required DataSource from the Context and passes it through to the resolver function:

```javascript
price: apiGetter((api, ...args) => api.productPrice(...args))
```

is the same as:

```javascript
price: async (root, params, context, info) => context.dataSources[{nameOfApi}].productPrice(root, params, context, info)
```

---

### Performance results

<details><summary>Test Queries</summary>
<p>

```graphql
query BackendConfig {
  backendConfig {
    activeLocale
    locales
    blog {
      _
    }
    shop {
      baseCurrency
      currencies
      activeCurrency
      stores {
        name
      }
    }
  }
}

query CategoryProducts {
  category(id: "11") {
    products(pagination: { perPage: 5 }) {
      items {
        id
        sku
        name

        breadcrumbs(
          path: "/women/tops-women/tees-women/desiree-fitness-tee.html"
        ) {
          urlPath
          name
        }
      }
    }
  }
}
```

</p>
</details>

<details><summary>Before the changes</summary>
<p>

- Fetching backend config (time to fetch WP config + worse time to fetch Magento result. It would grow arithmetically with a number of backends):

<img width="1216" alt="Screenshot 2019-08-28 at 14 07 46" src="https://user-images.githubusercontent.com/1118933/63854626-db6e5400-c99d-11e9-986f-bac67418e431.png">

- Fetching Category Products with nested data, breadcrumbs were added for the sake of a test, although we don't fetch them for a list of products (Falcon triggers the same GET request within a single GQL query 5 times - one per each product):

<img width="1074" alt="Screenshot 2019-08-28 at 14 20 35" src="https://user-images.githubusercontent.com/1118933/63855186-16bd5280-c99f-11e9-816e-5683edd7b725.png">

- Load tests:

```
All virtual users finished
Summary report @ 14:40:06(+0200) 2019-08-28
  Scenarios launched:  150
  Scenarios completed: 150
  Requests completed:  300
  RPS sent: 86.71
  Request latency:
    min: 0.9
    max: 771.6
    median: 2.3
    p95: 663.6
    p99: 712.6
  Scenario counts:
    0: 150 (100%)
  Codes:
    200: 300
```

</p>
</details>


<details><summary>After the changes</summary>
<p>

- Fetching backend config (worst time out of all requests):

<img width="1064" alt="Screenshot 2019-08-28 at 14 24 52" src="https://user-images.githubusercontent.com/1118933/63855491-d0b4be80-c99f-11e9-9629-c9ac8fd6f36a.png">

- Fetching Category Products with nested data (notice 1 request to Magento backend - all calls will get the same result using only 1 query):

<img width="1419" alt="Screenshot 2019-08-28 at 14 27 42" src="https://user-images.githubusercontent.com/1118933/63855617-1b363b00-c9a0-11e9-8949-6e11770d4ecf.png">

- Load testing (2 GET requests to Magento were made):

```
All virtual users finished
Summary report @ 14:32:05(+0200) 2019-08-28
  Scenarios launched:  150
  Scenarios completed: 150
  Requests completed:  300
  RPS sent: 86.71
  Request latency:
    min: 0.9
    max: 390.4
    median: 2
    p95: 170.9
    p99: 377.1
  Scenario counts:
    0: 150 (100%)
  Codes:
    200: 300
```

</p>
</details>

---

To code-reviewers: method/const names are open for a discussion.
(`Object` => `object` change is a bug with eslint, I apologize for this)