### PR TITLE
Introducing `@cacheId` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 ### Falcon Server vNext
 
 - improved Cache calls by tracking simultaneous requests with the same cache-key ([#557](https://github.com/deity-io/falcon/pull/557))
+- introduced `@cacheId` directive to assist to `@cache` for generating cache tags ([#608](https://github.com/deity-io/falcon/pull/608))
 
 ### Falcon Server Env vNext
 

--- a/packages/falcon-server/schema.graphql
+++ b/packages/falcon-server/schema.graphql
@@ -1,4 +1,5 @@
 directive @cache(ttl: Int, idPath: [String]) on FIELD_DEFINITION
+directive @cacheId on FIELD_DEFINITION
 directive @cacheInvalidator(idPath: [IdPathEntryInput]) on FIELD_DEFINITION
 
 schema {
@@ -45,7 +46,7 @@ type ResourceMeta {
   """
   Canonical URL for the found entity
   """
-  path: ID!
+  path: String! @cacheId
   """
   Entity type (this is being used by Dynamic Routing)
   """

--- a/packages/falcon-server/src/schemaDirectives/GraphQLCacheDirective.test.ts
+++ b/packages/falcon-server/src/schemaDirectives/GraphQLCacheDirective.test.ts
@@ -4,7 +4,10 @@ import { addResolveFunctionsToSchema } from 'graphql-tools';
 import { runQuery, buildSchema, buildSchemaAndRunQuery } from '../utils/testing';
 import { GraphQLCacheDirective } from './GraphQLCacheDirective';
 
-const directiveDefinition: string = `directive @cache(ttl: Int, idPath: [String]) on FIELD_DEFINITION`;
+const directiveDefinition: string = `
+directive @cache(ttl: Int, idPath: [String]) on FIELD_DEFINITION
+directive @cacheId on FIELD_DEFINITION
+`;
 
 const config = {
   cache: {
@@ -122,7 +125,7 @@ describe('@cache directive', () => {
         foo: Foo @cache
       }
       type Foo {
-        id: ID!
+        id: ID! @cacheId
         name: String
       }
     `;
@@ -132,7 +135,7 @@ describe('@cache directive', () => {
         foo: Foo @cache(ttl: 0)
       }
       type Foo {
-        id: ID!
+        id: ID! @cacheId
         name: String
       }
     `;
@@ -180,7 +183,7 @@ describe('@cache directive', () => {
           foo: Foo @cache
         }
         type Foo {
-          id: ID!
+          id: ID! @cacheId
           name: String
         }
       `;
@@ -213,7 +216,7 @@ describe('@cache directive', () => {
           foo: Foo @cache
         }
         type Foo {
-          id: ID!
+          id: ID! @cacheId
           name: String
         }
       `;
@@ -259,13 +262,13 @@ describe('@cache directive', () => {
           foo: Foo
         }
         type Foo {
-          id: ID!
+          id: ID! @cacheId
           name: String
           list: [Bar]! @cache(ttl: 1, idPath: ["$parent"])
           barList: BarList @cache(ttl: 1, idPath: ["$parent", "items"])
         }
         type Bar {
-          id: ID!
+          id: ID! @cacheId
           name: String
         }
         type BarList {

--- a/packages/falcon-server/src/schemaDirectives/GraphQLCacheInvalidatorDirective.test.ts
+++ b/packages/falcon-server/src/schemaDirectives/GraphQLCacheInvalidatorDirective.test.ts
@@ -3,12 +3,15 @@ import { KeyValueCache } from 'apollo-server-caching';
 import { buildSchemaAndRunQuery } from '../utils/testing';
 import { GraphQLCacheInvalidatorDirective } from './GraphQLCacheInvalidatorDirective';
 
-const directiveDefinition = `directive @cacheInvalidator(idPath: [IdPathEntryInput]) on FIELD_DEFINITION
+const directiveDefinition = `
+directive @cacheInvalidator(idPath: [IdPathEntryInput]) on FIELD_DEFINITION
+directive @cacheId on FIELD_DEFINITION
 
 input IdPathEntryInput {
   type: String
   path: String!
-}`;
+}
+`;
 
 const config = {
   cache: {
@@ -39,7 +42,7 @@ describe('@cacheInvalidator directive', () => {
         foo: Foo @cacheInvalidator
       }
       type Foo {
-        id: ID!
+        id: ID! @cacheId
         name: String
       }
     `;
@@ -71,7 +74,7 @@ describe('@cacheInvalidator directive', () => {
         items: [FooItem]
       }
       type FooItem {
-        id: ID!
+        id: ID! @cacheId
         name: String
       }
     `;

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -297,7 +297,7 @@ type ProductTierPrice {
 
 type Product {
   id: ID!
-  sku: ID!
+  sku: ID! @cacheId
   name: String!
   image: String
   urlPath: String!
@@ -348,7 +348,7 @@ type PaymentMethod {
 }
 
 type MenuItem {
-  id: ID!
+  id: ID! @cacheId
   name: String!
   urlPath: String!
   cssClass: String
@@ -356,7 +356,7 @@ type MenuItem {
 }
 
 type Category {
-  id: ID!
+  id: ID! @cacheId
   name: String
   children: [Category]
   description: String


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
Yes. Falcon won't be checking for `ID` field types anymore, but instead, it will be checking for `@cacheId`-marked fields within the same Type.

**Other information:**
Fixes #587 