### PR TITLE
fix apollo versions so yarn doesn't install 2 versions of some packages

### DIFF
--- a/examples/shop-with-blog/client/package.json
+++ b/examples/shop-with-blog/client/package.json
@@ -21,8 +21,8 @@
     "node": ">=8.10"
   },
   "dependencies": {
-    "@apollo/react-hoc": "3.1.1",
-    "@apollo/react-hooks": "3.1.1",
+    "@apollo/react-hoc": "^3.1.2",
+    "@apollo/react-hooks": "^3.1.2",
     "@deity/falcon-adyen-plugin": "^1.0.0",
     "@deity/falcon-blog-data": "^1.0.0",
     "@deity/falcon-client": "^2.0.0",

--- a/packages/falcon-client/package.json
+++ b/packages/falcon-client/package.json
@@ -21,9 +21,9 @@
     ]
   },
   "dependencies": {
-    "@apollo/react-common": "3.1.1",
-    "@apollo/react-hoc": "3.1.1",
-    "@apollo/react-ssr": "3.1.1",
+    "@apollo/react-common": "^3.1.2",
+    "@apollo/react-hoc": "^3.1.2",
+    "@apollo/react-ssr": "^3.1.2",
     "@babel/code-frame": "7.5.5",
     "@babel/core": "7.5.5",
     "@babel/preset-env": "7.5.5",
@@ -115,7 +115,7 @@
     "workbox-routing": "4.3.1"
   },
   "devDependencies": {
-    "@apollo/react-testing": "^3.1.1",
+    "@apollo/react-testing": "^3.1.2",
     "@deity/falcon-front-kit": "^1.0.0",
     "@deity/falcon-server": "^2.0.0",
     "@types/fs-extra": "8.0.0",

--- a/packages/falcon-data/package.json
+++ b/packages/falcon-data/package.json
@@ -26,8 +26,8 @@
     "core-js": "3.1.4"
   },
   "devDependencies": {
-    "@apollo/react-common": "3.1.1",
-    "@apollo/react-components": "3.1.1",
+    "@apollo/react-common": "^3.1.2",
+    "@apollo/react-components": "^3.1.2",
     "@deity/falcon-scripts": "^1.0.0",
     "@types/prop-types": "15.7.1",
     "@types/react": "16.8.22",
@@ -37,8 +37,8 @@
     "react": "16.8.6"
   },
   "peerDependencies": {
-    "@apollo/react-common": "^3.1.1",
-    "@apollo/react-components": "^3.1.1",
+    "@apollo/react-common": "^3.1.2",
+    "@apollo/react-components": "^3.1.2",
     "apollo-client": "^2.6.4",
     "graphql-tag": "^2.10.1",
     "react": "^16.8.6"

--- a/packages/falcon-front-kit/package.json
+++ b/packages/falcon-front-kit/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@babel/runtime": "7.5.5",
-    "@apollo/react-common": "3.1.1",
-    "@apollo/react-hoc": "3.1.1",
+    "@apollo/react-common": "^3.1.2",
+    "@apollo/react-hoc": "^3.1.2",
     "@deity/falcon-data": "^1.0.0",
     "@deity/falcon-shop-data": "^1.0.0",
     "core-js": "3.1.4",
@@ -40,7 +40,7 @@
     "qs": "6.6.0"
   },
   "devDependencies": {
-    "@apollo/react-testing": "^3.1.1",
+    "@apollo/react-testing": "^3.1.2",
     "@deity/falcon-i18n": "^1.0.0",
     "@deity/falcon-scripts": "^1.0.0",
     "@deity/falcon-shop-extension": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,61 +2,61 @@
 # yarn lockfile v1
 
 
-"@apollo/react-common@3.1.1", "@apollo/react-common@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.1.tgz#540619d8276d750ce4f381c9cf8f51a6f657f75d"
-  integrity sha512-lMiczOm4sD16eI9Ai+AUY+Jl3C/FNm4IpoZiAbe35TqMuD7HpZ4OJmXAbT3CzfrAqsKK8+rHgRvTiPI2kQjIWg==
+"@apollo/react-common@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.2.tgz#19feb1d264c1e82e9610f68298a9dd89513060ea"
+  integrity sha512-6+gTeBZoIyCE6VnHD2EI9Wz+Dm05MBxplUTmVgswzvTe05lUO78SxGgB3XJc9GM/TmNexgCc0eS84vUpG/f6Tg==
   dependencies:
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-components@3.1.1", "@apollo/react-components@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.1.tgz#dde560f0296318d230a5e73b9b450a881baace29"
-  integrity sha512-ozoq3XkHZKXrLQUOTZlbbPg9SvZryPQCRhTl+WJZu75ysaAKbwl6iVt+emBymZ5/eNXSUSdxqnOCX281sFLRRw==
+"@apollo/react-components@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.2.tgz#41dc02dab2d97070bef08f7cf1849200b4ca2296"
+  integrity sha512-D1habJ8IvylC8KpgzlM6yYskYGcTYuyOU5cPgtluamTc4ro6P/98bILMO4qHDDj0zkBARIgHrf2QV6oityTfvA==
   dependencies:
-    "@apollo/react-common" "^3.1.1"
-    "@apollo/react-hooks" "^3.1.1"
+    "@apollo/react-common" "^3.1.2"
+    "@apollo/react-hooks" "^3.1.2"
     prop-types "^15.7.2"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-hoc@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.1.tgz#e02ee62792924a13b8e4e023899fdb74333060f8"
-  integrity sha512-j6ITPSFmZnaw+tWzjqh25Ib2jBzOPpyBFsh1u0Ep4oJWFhCHwGLFAns0I6aAWP8a+3R0P7ZarwEVy56ylKG58w==
+"@apollo/react-hoc@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.2.tgz#c1cb8c2afe7c22f432f0880d33a3034c671e0423"
+  integrity sha512-VbykBrxPBurt/yIAK8oFg7ZHL5ls2QI1y93AtLqJNwe4oM0m3oJC2jGIr2jobSVhbmGdzIGWshKJTbtrRowQ3g==
   dependencies:
-    "@apollo/react-common" "^3.1.1"
-    "@apollo/react-components" "^3.1.1"
+    "@apollo/react-common" "^3.1.2"
+    "@apollo/react-components" "^3.1.2"
     hoist-non-react-statics "^3.3.0"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-hooks@3.1.1", "@apollo/react-hooks@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.1.tgz#8e5a0f281a9778aaf17496ad38a178d23375077c"
-  integrity sha512-LwE4olNlKwqh1hl6iHr/igSDGRVs7c6Ik5MYZm9TzGj01f+ebhM1+Pn+UBNLsb3uRuytZsUOsEDBEXMABzC9Tw==
+"@apollo/react-hooks@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.2.tgz#3f889f9448ebb32faf164117f1f63d9ffa18f5d9"
+  integrity sha512-PV5u40E9iwfwM7u61r2P9PTjcGaM3zRwiwrJGDKOKaOn1Y9wTHhKOVEQa7YOsCWciSaMVK1slpKMvQbD2Ypqtw==
   dependencies:
-    "@apollo/react-common" "^3.1.1"
+    "@apollo/react-common" "^3.1.2"
     "@wry/equality" "^0.1.9"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-ssr@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.1.tgz#4952c02c4131334edaaa4af1c2668801ac656471"
-  integrity sha512-Jbh3bpkqmp5k5KGZNcKgpGiChlUB3kVkFxzuqC4Tzx5u1gg47dPuS950j3LeMLD6ZRFhwryMnMtBsLu8iceE/Q==
+"@apollo/react-ssr@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.2.tgz#ebb79bf94a5ab760e5152ab5f0371e64ec4041ad"
+  integrity sha512-kBuinaib6+QBoDfc5n/bvRxu+6QnuvQl1mZ5ThBSO+6aL5aJtQYZsblJyC5R/Zx6koJilq6+oZfL510wOlFeEw==
   dependencies:
-    "@apollo/react-common" "^3.1.1"
-    "@apollo/react-hooks" "^3.1.1"
+    "@apollo/react-common" "^3.1.2"
+    "@apollo/react-hooks" "^3.1.2"
     tslib "^1.10.0"
 
-"@apollo/react-testing@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.1.tgz#27a8fb268604f785cf7c1d284a734acfbe039e05"
-  integrity sha512-tjZ5zQ8WRSu4gXCfhNWDt3rgsunFZ7QapyDNp9ykVIuC/JrusUdbGieq9PajZsmLZUMOfQUEEoWBNRWNAsXlJw==
+"@apollo/react-testing@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.2.tgz#82bac9ce3033470e4ff145642cd271d33b32296b"
+  integrity sha512-nADLe8ju6K7LinKy5bJnN8cXMeje/s7zNIfKESviQz09+AOORFHtDPlgQPwkaogNor4yTKFwrrwtvokhRu8tnQ==
   dependencies:
-    "@apollo/react-common" "^3.1.1"
+    "@apollo/react-common" "^3.1.2"
     fast-json-stable-stringify "^2.0.0"
     tslib "^1.10.0"
 


### PR DESCRIPTION
This PR fixes issue with yarn installing two versions of @apollo/react-common and @apollo/react-components (it was installing `3.1.1` because our packages required that version and `3.1.2` because apollo packages have `^3.1.1` specified)