### PR TITLE
Adding Codecov pipeline step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - name: install dependencies
+      - name: Install Falcon dependencies
         run: yarn --non-interactive --frozen-lockfile
-      - name: lint files
+      - name: Lint project files
         run: yarn lint
-      - name: run tests
+      - name: Run Falcon tests
         run: yarn test
-      - uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+      - name: Collect Code Coverage
+        run: yarn coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
         run: yarn lint
       - name: run tests
         run: yarn test
-      - uses: actions/checkout@v1
+      - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,6 @@ jobs:
         run: yarn lint
       - name: run tests
         run: yarn test
-      - name: get coverage
-        run: yarn coverage
+      - uses: actions/checkout@v1
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Run Falcon tests
         run: yarn test
       - name: Collect Code Coverage
-        run: yarn coverage
+        run: yarn coverage -t ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: yes
+
 coverage:
   status:
     project:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@deity/eslint-config-falcon": "^1.0.0",
     "chalk": "2.4.1",
-    "codecov": "3.1.0",
+    "codecov": "3.6.1",
     "commander": "2.19.0",
     "cross-env": "5.2.0",
     "eslint": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,15 +5819,15 @@ code-point-at@^1.0.0:
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/codecov/-/codecov-3.1.0.tgz#340bd968d361f256976b5af782dd8ba9f82bc849"
-  integrity sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==
+codecov@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.npmjs.org/codecov/-/codecov-3.6.1.tgz#f39fc49413445555f81f8e3ca5730992843b4517"
+  integrity sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==
   dependencies:
     argv "^0.0.2"
     ignore-walk "^3.0.1"
-    js-yaml "^3.12.0"
-    request "^2.87.0"
+    js-yaml "^3.13.1"
+    teeny-request "^3.11.3"
     urlgrey "^0.4.4"
 
 codemirror@^5.42.2:
@@ -18101,6 +18101,15 @@ tar@^4.4.10:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+teeny-request@^3.11.3:
+  version "3.11.3"
+  resolved "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
+  integrity sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    node-fetch "^2.2.0"
+    uuid "^3.3.2"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Brings Codecov reports back.

Fixes #635 (Using `codecov-action` on Github Actions takes a lot more time than simply running `yarn coverage` command inside of the project - I decided not to use it)