### PR TITLE
Country region required fields

### DIFF
--- a/packages/falcon-shop-data/src/Address/AddressQuery.tsx
+++ b/packages/falcon-shop-data/src/Address/AddressQuery.tsx
@@ -13,13 +13,13 @@ export const GET_ADDRESS = gql`
       city
       postcode
       region {
-        id
+        name
       }
       country {
         id
         code
         regions {
-          id
+          name
         }
       }
       company
@@ -43,9 +43,9 @@ export type AddressResponse = {
     | 'defaultBilling'
     | 'defaultShipping'
   > & {
-    region: Pick<Region, 'id'>;
+    region: Pick<Region, 'name'>;
     country: Pick<Country, 'id' | 'code'> & {
-      regions: Pick<Region, 'id'>[];
+      regions: Pick<Region, 'name'>[];
     };
   };
 };

--- a/packages/falcon-shop-data/src/Customer/CustomerWithAddressesQuery.tsx
+++ b/packages/falcon-shop-data/src/Customer/CustomerWithAddressesQuery.tsx
@@ -18,7 +18,7 @@ export const GET_CUSTOMER_WITH_ADDRESSES = gql`
         postcode
         city
         region {
-          id
+          name
         }
         country {
           id
@@ -47,7 +47,7 @@ export type CustomerWithAddressesResponse = {
       | 'defaultBilling'
       | 'defaultShipping'
     > & {
-      region: Pick<Region, 'id'>;
+      region: Pick<Region, 'name'>;
       country: Pick<Country, 'id' | 'code'>;
     })[];
   };

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -668,11 +668,11 @@ type BundleProductOptionLink {
 
 type Region {
   # unique identifier of the region
-  id: ID!
+  id: ID
   # abbreviated form of the region name
   code: String
   # region name
-  name: String
+  name: String!
 }
 
 type Country {

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -677,7 +677,7 @@ type Region {
 
 type Country {
   # unique identifier of the country
-  id: ID!
+  id: ID
   # abbreviated form of the country name
   code: String!
   # country name in English

--- a/packages/falcon-shop-extension/src/types.ts
+++ b/packages/falcon-shop-extension/src/types.ts
@@ -372,7 +372,7 @@ export type CountryList = {
 };
 
 export type Country = {
-  id: number;
+  id?: number;
   code: string;
   englishName?: string;
   localName?: string;

--- a/packages/falcon-shop-extension/src/types.ts
+++ b/packages/falcon-shop-extension/src/types.ts
@@ -380,9 +380,9 @@ export type Country = {
 };
 
 export type Region = {
-  id: string;
+  id?: string;
   code?: string;
-  name?: string;
+  name: string;
 };
 
 export type MenuItem = {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Minor schema change.

**What is the current behavior? (You can also link to an open issue here)**

On `type Country`, both `id` and `code` are required. On `type Region`, the field `id` is required.

**What is the new behavior (if this is a feature change)?**

On `type Country`, only `code` is required, while `id` is made optional. On `type Region`, the field `id` is made optional, while `name` is made required.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

Users need to make sure the `name` field is included on any object of type `Region`.