### PR TITLE
Enabling falcon-front-kit to export SearchContext + dependency update

### DIFF
--- a/packages/falcon-front-kit/src/Search/index.ts
+++ b/packages/falcon-front-kit/src/Search/index.ts
@@ -1,5 +1,5 @@
 export * from './searchState';
-export * from './SearchContext';
 export * from './SearchContextValue';
 export * from './SearchProvider';
 export * from './SearchConsumer';
+export * from './useSearchContext';

--- a/packages/falcon-front-kit/src/Search/index.ts
+++ b/packages/falcon-front-kit/src/Search/index.ts
@@ -1,4 +1,5 @@
 export * from './searchState';
+export * from './SearchContext';
 export * from './SearchContextValue';
 export * from './SearchProvider';
 export * from './SearchConsumer';

--- a/packages/falcon-front-kit/src/Search/useSearchContext.ts
+++ b/packages/falcon-front-kit/src/Search/useSearchContext.ts
@@ -1,4 +1,4 @@
 import { useContext } from 'react';
 import { SearchContext } from './SearchContext';
 
-export const useSearchContext = useContext(SearchContext);
+export const useSearchContext = () => useContext(SearchContext);

--- a/packages/falcon-front-kit/src/Search/useSearchContext.ts
+++ b/packages/falcon-front-kit/src/Search/useSearchContext.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { SearchContext } from './SearchContext';
+
+export const useSearchContext = useContext(SearchContext);

--- a/packages/falcon-ui-kit/package.json
+++ b/packages/falcon-ui-kit/package.json
@@ -29,7 +29,7 @@
     "core-js": "3.2.1",
     "history": "4.9.0",
     "react-credit-card-input": "1.1.5",
-    "react-lazyload": "2.6.2",
+    "react-lazyload": "^2.6.5",
     "react-powerplug": "1.0.0",
     "react-responsive": "6.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14880,10 +14880,10 @@ react-is@^16.10.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
-react-lazyload@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.6.2.tgz#6a1660de6e8653632797539189d19d64e924482c"
-  integrity sha512-zbFiwI3H7W0/Qvb6T/ew2NiGe2wj+soYNW7vv5Dte1eZuJDvvyUOHo8GpYfEeWoP5x4Rree2Hwop+lCISalBwg==
+react-lazyload@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.6.5.tgz#7a5ac001f0f8aeddc10c30e4ce318c10f13aa723"
+  integrity sha512-C/juO9l7dGS7jEARBLjM3oG7F1lL5bqajz/55sk3GFc0Ippd9vnSkdRxdiaE6gf5si3YxIow8dSJ+YuB2D/3vg==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
- Re-exporting `SearchContext` to enable calling `useContext(SearchContext)`
- Updating "react-lazyload" dependency to fix the image loading