### PR TITLE
Inlining SVG files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 - fixed custom error `500.html` view resolution ([#662](https://github.com/deity-io/falcon/pull/662))
 - fixed handling of redirects by serviceworker ([#594](https://github.com/deity-io/falcon/pull/594))
 - fixed the `next` value for sign-in redirects ([#689](https://github.com/deity-io/falcon/pull/689))
+- improved a way of processing the `svg` files ([#726](https://github.com/deity-io/falcon/pull/726))
 
 ### Falcon I18n vNext
 

--- a/packages/falcon-client/build-utils/webpack/config/create.js
+++ b/packages/falcon-client/build-utils/webpack/config/create.js
@@ -218,7 +218,8 @@ module.exports = (target = 'web', options) => {
             /\.html$/,
             /\.(vue)$/,
             /\.(re)$/,
-            /\.(webmanifest|browserconfig)$/
+            /\.(webmanifest|browserconfig)$/,
+            /\.svg$/
           ],
           loader: require.resolve('file-loader'),
           options: {

--- a/packages/falcon-dev-tools/babel-preset-falcon-client/index.js
+++ b/packages/falcon-dev-tools/babel-preset-falcon-client/index.js
@@ -1,3 +1,5 @@
+const svgoConfig = require('./svgoConfig');
+
 module.exports = (/* api */) => {
   const preset = {
     presets: [
@@ -24,7 +26,8 @@ module.exports = (/* api */) => {
       require.resolve('@babel/plugin-syntax-dynamic-import'), // Adds syntax support for import()
       // Add support for loadable components SSR
       // https://www.smooth-code.com/open-source/loadable-components/docs/server-side-rendering/
-      require.resolve('@loadable/babel-plugin')
+      require.resolve('@loadable/babel-plugin'),
+      [require.resolve('babel-plugin-inline-react-svg'), { svgo: svgoConfig }]
     ]
   };
 

--- a/packages/falcon-dev-tools/babel-preset-falcon-client/package.json
+++ b/packages/falcon-dev-tools/babel-preset-falcon-client/package.json
@@ -20,6 +20,7 @@
     "@loadable/babel-plugin": "5.7.2",
     "babel-plugin-dynamic-import-node": "2.3.0",
     "babel-plugin-graphql-tag": "2.5.0",
+    "babel-plugin-inline-react-svg": "1.1.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24"
   }
 }

--- a/packages/falcon-dev-tools/babel-preset-falcon-client/svgoConfig.js
+++ b/packages/falcon-dev-tools/babel-preset-falcon-client/svgoConfig.js
@@ -1,0 +1,33 @@
+/**
+ * because `babel-plugin-inline-react-svg` overrides defaults,
+ * we take them from official `svgo` docs https://github.com/svg/svgo/blob/master/README.md
+ */
+const svgoConfig = {
+  plugins: [
+    { cleanupIDs: true },
+    { removeTitle: true },
+    { removeDoctype: true },
+    { removeComments: true },
+    { cleanupAttrs: true },
+    { inlineStyles: true },
+    { removeXMLProcInst: true },
+    { removeMetadata: true },
+    { removeDesc: true },
+    { removeUselessDefs: true },
+    { removeEditorsNSData: true },
+    { removeEmptyAttrs: true },
+    { removeHiddenElems: true },
+    { removeEmptyText: true },
+    { removeEmptyContainers: true },
+    { minifyStyles: true },
+    { removeUnknownsAndDefaults: true },
+    { removeNonInheritableGroupAttrs: true },
+    { removeUselessStrokeAndFill: true },
+    { removeUnusedNS: true },
+    { cleanupNumericValues: true },
+    { sortDefsChildren: true },
+    { removeAttrs: { attrs: '(data-name)' } }
+  ]
+};
+
+module.export = svgoConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4189,6 +4189,17 @@ babel-plugin-graphql-tag@2.5.0:
     babel-literal-to-ast "^2.1.0"
     debug "^4.1.1"
 
+babel-plugin-inline-react-svg@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.0.tgz#b39519c78249b3fcf895b541c38b485a2b11b0be"
+  integrity sha512-Y/tBMi7Jh7Jh+DGcSNsY9/RW33nvcR067HFK0Dp+03jpidil1sJAffBdajK72xn3tbwMsgFLJubxW5xpQLJytA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    lodash.isplainobject "^4.0.6"
+    resolve "^1.10.0"
+    svgo "^0.7.2"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz#7981590f1956d75d67630ba46f0c22493588c893"
@@ -5102,6 +5113,13 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+clap@^1.0.9:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
+  integrity sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==
+  dependencies:
+    chalk "^1.1.3"
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -5260,6 +5278,13 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+coa@~1.0.1:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
+  integrity sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=
+  dependencies:
+    q "^1.1.2"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -5347,6 +5372,11 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+colors@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
 columnify@^1.5.4:
   version "1.5.4"
@@ -6171,6 +6201,14 @@ csso@^3.5.1:
   integrity sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==
   dependencies:
     css-tree "1.0.0-alpha.29"
+
+csso@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
+  integrity sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=
+  dependencies:
+    clap "^1.0.9"
+    source-map "^0.5.3"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.6"
@@ -7422,6 +7460,11 @@ espree@^6.0.0:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+esprima@^2.6.0:
+  version "2.7.3"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -10710,6 +10753,14 @@ js-yaml@3.13.1, js-yaml@^3.13.1, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -11373,6 +11424,11 @@ lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.iteratee@^4.5.0:
   version "4.7.0"
@@ -15915,7 +15971,7 @@ sass-loader@^7.1.0:
     pify "^3.0.0"
     semver "^5.5.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -16977,6 +17033,19 @@ supports-color@^6.0.0, supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+svgo@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
+  integrity sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=
+  dependencies:
+    coa "~1.0.1"
+    colors "~1.1.2"
+    csso "~2.3.1"
+    js-yaml "~3.7.0"
+    mkdirp "~0.5.1"
+    sax "~1.2.1"
+    whet.extend "~0.9.9"
 
 svgo@^1.0.0, svgo@^1.1.1:
   version "1.3.0"
@@ -18298,6 +18367,11 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+whet.extend@~0.9.9:
+  version "0.9.9"
+  resolved "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
+  integrity sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
when `.svg` files will be `import`ed or `require`ed then it will be converted (via `babel`) into react component and rendered inline 
moreover `.svg` files will be processed via `svgo` in order to optimize them

fix: https://github.com/deity-io/falcon/issues/605

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

**Other information:**
