### PR TITLE
Refetch queries fix

### DIFF
--- a/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
@@ -51,6 +51,7 @@ export default ({ contentType, open, close }) => {
                   <SignInForm
                     id="sign-in-sidebar"
                     onSuccess={close}
+                    mutationOptions={{ awaitRefetchQueries: true }}
                     onForgotPassword={() => open({ variables: { contentType: SIDEBAR_TYPE.forgotPassword } })}
                   />
                   <Divider my="lg" />

--- a/packages/falcon-data/src/BackendConfig/SetLocaleMutation.tsx
+++ b/packages/falcon-data/src/BackendConfig/SetLocaleMutation.tsx
@@ -21,6 +21,7 @@ export type SetLocaleInput = {
 export class SetLocaleMutation extends Mutation<SetLocaleResponse, SetLocaleInput> {
   static defaultProps = {
     mutation: SET_LOCALE,
-    refetchQueries: ['BackendConfig']
+    refetchQueries: ['BackendConfig'],
+    awaitRefetchQueries: true
   };
 }

--- a/packages/falcon-front-kit/src/Account/ChangePasswordFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/ChangePasswordFormProvider.tsx
@@ -7,7 +7,7 @@ import { FormProviderProps } from '../Forms';
 
 export type ChangePasswordFormProviderProps = FormProviderProps<ChangePasswordInput, ChangePasswordResponse>;
 export const ChangePasswordFormProvider: React.SFC<ChangePasswordFormProviderProps> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues: ChangePasswordInput = {
     currentPassword: '',
     password: ''
@@ -21,7 +21,7 @@ export const ChangePasswordFormProvider: React.SFC<ChangePasswordFormProviderPro
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        changePasswordMutation({ variables: { input: values } })
+        changePasswordMutation({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Account/EditCustomerFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/EditCustomerFormProvider.tsx
@@ -9,7 +9,7 @@ export type EditCustomerFormProviderProps = FormProviderProps<EditCustomerInput,
   customer: Pick<Customer, 'websiteId' | 'firstname' | 'lastname' | 'email'>;
 };
 export const EditCustomerFormProvider: React.SFC<EditCustomerFormProviderProps> = props => {
-  const { onSuccess, initialValues, customer, ...formikProps } = props;
+  const { onSuccess, initialValues, customer, mutationOptions, ...formikProps } = props;
   const defaultInitialValues: EditCustomerInput = {
     websiteId: customer.websiteId,
     email: customer.email,
@@ -25,7 +25,7 @@ export const EditCustomerFormProvider: React.SFC<EditCustomerFormProviderProps> 
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        editCustomerMutation({ variables: { input: values } })
+        editCustomerMutation({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Account/ForgotPasswordFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/ForgotPasswordFormProvider.tsx
@@ -10,7 +10,7 @@ export type ForgotPasswordFormProviderProps = FormProviderProps<
   RequestPasswordResetResponse
 >;
 export const ForgotPasswordFormProvider: React.SFC<ForgotPasswordFormProviderProps> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues: RequestPasswordResetInput = {
     email: ''
   };
@@ -23,7 +23,7 @@ export const ForgotPasswordFormProvider: React.SFC<ForgotPasswordFormProviderPro
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        requestPasswordReset({ variables: { input: values } })
+        requestPasswordReset({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Account/ResetPasswordFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/ResetPasswordFormProvider.tsx
@@ -7,7 +7,7 @@ import { FormProviderProps } from '../Forms';
 
 export type ResetPasswordFormProviderProps = FormProviderProps<ResetPasswordInput, ResetPasswordResponse>;
 export const ResetPasswordFormProvider: React.SFC<ResetPasswordFormProviderProps> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues: ResetPasswordInput = {
     resetToken: '',
     password: ''
@@ -21,7 +21,7 @@ export const ResetPasswordFormProvider: React.SFC<ResetPasswordFormProviderProps
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        resetPassword({ variables: { input: values } })
+        resetPassword({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Account/SignInFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/SignInFormProvider.tsx
@@ -10,7 +10,7 @@ export type SignInFormValues = {
 };
 export type SignInFormProvider = FormProviderProps<SignInFormValues, SignInResponse>;
 export const SignInFormProvider: React.SFC<SignInFormProvider> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues = {
     email: '',
     password: ''
@@ -24,7 +24,7 @@ export const SignInFormProvider: React.SFC<SignInFormProvider> = props => {
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        signIn({ variables: { input: values } })
+        signIn({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Account/SignUpFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Account/SignUpFormProvider.tsx
@@ -13,7 +13,7 @@ export type SignUpFormValues = {
 };
 export type SignUpFormProviderProps = FormProviderProps<SignUpFormValues, SignUpResponse>;
 export const SignUpFormProvider: React.SFC<SignUpFormProviderProps> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues: SignUpFormValues = {
     firstname: '',
     lastname: '',
@@ -30,7 +30,7 @@ export const SignUpFormProvider: React.SFC<SignUpFormProviderProps> = props => {
       initialStatus={{}}
       initialValues={initialValues || defaultInitialValues}
       onSubmit={(values, { setSubmitting, setStatus }) =>
-        signUp({ variables: { input: values } })
+        signUp({ variables: { input: values }, ...(mutationOptions || {}) })
           .then(({ data }) => {
             setSubmitting(false);
             setStatus({ data });

--- a/packages/falcon-front-kit/src/Address/AddAddressFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Address/AddAddressFormProvider.tsx
@@ -22,7 +22,7 @@ export type AddAddressFormValues = {
 
 export type AddAddressFormProviderProps = FormProviderProps<AddAddressFormValues, AddAddressResponse>;
 export const AddAddressFormProvider: React.SFC<AddAddressFormProviderProps> = props => {
-  const { onSuccess, initialValues, ...formikProps } = props;
+  const { onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const defaultInitialValues = {
     firstname: '',
     lastname: '',
@@ -54,7 +54,8 @@ export const AddAddressFormProvider: React.SFC<AddAddressFormProviderProps> = pr
               countryId: country.id,
               regionId: region ? region.id : undefined
             }
-          }
+          },
+          ...(mutationOptions || {})
         })
           .then(({ data }) => {
             setSubmitting(false);

--- a/packages/falcon-front-kit/src/Address/EditAddressFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Address/EditAddressFormProvider.tsx
@@ -24,7 +24,7 @@ export type EditAddressFormProviderProps = FormProviderProps<EditAddressFormValu
   address: Address;
 };
 export const EditAddressFormProvider: React.SFC<EditAddressFormProviderProps> = props => {
-  const { address, onSuccess, initialValues, ...formikProps } = props;
+  const { address, onSuccess, initialValues, mutationOptions, ...formikProps } = props;
   const { __typename, street, ...rest } = address;
   const defaultInitialValues = {
     street1: street.length > 0 ? street[0] : undefined,
@@ -49,7 +49,8 @@ export const EditAddressFormProvider: React.SFC<EditAddressFormProviderProps> = 
               countryId: country.id,
               regionId: region ? region.id : undefined
             }
-          }
+          },
+          ...(mutationOptions || {})
         })
           .then(({ data }) => {
             setSubmitting(false);

--- a/packages/falcon-front-kit/src/Checkout/SetCheckoutAddressFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Checkout/SetCheckoutAddressFormProvider.tsx
@@ -43,7 +43,7 @@ export type SetCheckoutAddressFormProviderProps = FormProviderProps<SetCheckoutA
   address?: CheckoutAddress | Address;
 };
 export const SetCheckoutAddressFormProvider: React.SFC<SetCheckoutAddressFormProviderProps> = props => {
-  const { initialValues, setAddress, address, onSuccess, ...formikProps } = props;
+  const { initialValues, setAddress, address, onSuccess, mutationOptions, ...formikProps } = props;
   const isMounted = React.useRef(true);
   const [getUserError] = useGetUserError();
 
@@ -60,10 +60,13 @@ export const SetCheckoutAddressFormProvider: React.SFC<SetCheckoutAddressFormPro
       initialValues={address ? checkoutAddressToSetCheckoutAddressFormValues(address) : initialValues}
       enableReinitialize
       onSubmit={({ street1, street2, ...values }, { setSubmitting, setStatus }) =>
-        setAddress({
-          ...values,
-          street: [street1, street2].filter(Boolean)
-        })
+        setAddress(
+          {
+            ...values,
+            street: [street1, street2].filter(Boolean)
+          },
+          mutationOptions
+        )
           .then(() => {
             const successData = {
               ...values,

--- a/packages/falcon-front-kit/src/DynamicRoute/DynamicRoute.tsx
+++ b/packages/falcon-front-kit/src/DynamicRoute/DynamicRoute.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Redirect, matchPath, match as Match, SwitchProps } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import { Location } from 'history';
-import { UrlQuery, ResourceMeta, Loader, OperationError } from '@deity/falcon-data';
+import { UrlQuery, ResourceMeta } from '@deity/falcon-data';
 import { Router } from '../Router';
 
 export type DynamicRouteComponentProps = Pick<ResourceMeta, 'id' | 'path'>;

--- a/packages/falcon-front-kit/src/Forms/Form.tsx
+++ b/packages/falcon-front-kit/src/Forms/Form.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form as FormikForm, FormikFormProps, useFormikContext } from 'formik';
-import { Loader } from '@deity/falcon-data';
 import { FormContext, FormContextValue } from './FormContext';
 
 export type FormProps = FormContextValue &

--- a/packages/falcon-front-kit/src/Forms/FormProvider.ts
+++ b/packages/falcon-front-kit/src/Forms/FormProvider.ts
@@ -1,7 +1,9 @@
 import { FormikProps, FormikValues } from 'formik';
+import { MutationFunctionOptions } from '@apollo/react-common';
 import { ErrorModel } from '@deity/falcon-data';
 
 export type FormProviderProps<TValues = FormikValues, TResult = any> = {
+  mutationOptions?: Pick<MutationFunctionOptions<TResult>, 'awaitRefetchQueries' | 'refetchQueries' | 'fetchPolicy'>;
   /** Invoked when form is successfully submit */
   onSuccess?: Function | ((data: TResult) => any);
   initialValues?: TValues;

--- a/packages/falcon-front-kit/src/Product/AddToCartFormProvider.tsx
+++ b/packages/falcon-front-kit/src/Product/AddToCartFormProvider.tsx
@@ -19,7 +19,7 @@ export type AddToCartFormProviderProps = FormProviderProps<AddToCartFormValues, 
   };
 };
 export const AddToCartFormProvider: React.SFC<AddToCartFormProviderProps> = props => {
-  const { onSuccess, initialValues, quantity, product, ...formikProps } = props;
+  const { onSuccess, initialValues, quantity, product, mutationOptions, ...formikProps } = props;
   const defaultInitialValues = {
     qty: quantity,
     options: productOptionsToForm(product.options),
@@ -42,7 +42,8 @@ export const AddToCartFormProvider: React.SFC<AddToCartFormProviderProps> = prop
               options: formProductOptionsToInput(values.options),
               bundleOptions: undefined // values.bundleOptions as any - TODO: add appropriate mapper
             }
-          }
+          },
+          ...(mutationOptions || {})
         })
           .then(({ data }) => {
             setSubmitting(false);

--- a/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
+import { Loader } from '@deity/falcon-data';
 import { IsAuthenticatedQuery } from '@deity/falcon-shop-data';
 
 export type OnlyUnauthenticatedRouteProps = {
@@ -26,18 +27,19 @@ export class OnlyUnauthenticatedRoute extends React.Component<OnlyUnauthenticate
       <Route
         {...rest}
         render={props => (
-          <IsAuthenticatedQuery>
-            {({ data }) =>
-              data.customer ? (
-                <Redirect
-                  to={{
-                    pathname: redirectTo
-                  }}
-                />
-              ) : (
-                <Component {...props} />
-              )
-            }
+          <IsAuthenticatedQuery fetchPolicy="network-only" passLoading>
+            {({ data, loading }) => {
+              if (loading) {
+                // we can not render anything until we do not known if customer is authenticated or not
+                return <Loader />;
+              }
+
+              if (data.customer) {
+                return <Redirect to={{ pathname: redirectTo }} />;
+              }
+
+              return <Component {...props} />;
+            }}
           </IsAuthenticatedQuery>
         )}
       />

--- a/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
@@ -27,7 +27,7 @@ export class OnlyUnauthenticatedRoute extends React.Component<OnlyUnauthenticate
       <Route
         {...rest}
         render={props => (
-          <IsAuthenticatedQuery fetchPolicy="network-only" passLoading>
+          <IsAuthenticatedQuery passLoading>
             {({ data, loading }) => {
               if (loading) {
                 // we can not render anything until we do not known if customer is authenticated or not

--- a/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/OnlyUnauthenticatedRoute.tsx
@@ -30,7 +30,7 @@ export class OnlyUnauthenticatedRoute extends React.Component<OnlyUnauthenticate
           <IsAuthenticatedQuery passLoading>
             {({ data, loading }) => {
               if (loading) {
-                // we can not render anything until we do not known if customer is authenticated or not
+                // we can not render anything until we get know if the customer is authenticated or not
                 return <Loader />;
               }
 

--- a/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
@@ -30,7 +30,7 @@ export class ProtectedRoute extends React.Component<ProtectedRouteProps> {
           <IsAuthenticatedQuery passLoading>
             {({ data, loading }) => {
               if (loading) {
-                // we can not render anything until we do not known if customer is authenticated or not
+                // we can not render anything until we get know if the customer is authenticated or not
                 return <Loader />;
               }
 

--- a/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
+import { Loader } from '@deity/falcon-data';
 import { IsAuthenticatedQuery } from '@deity/falcon-shop-data';
 
 export type ProtectedRouteProps = {
@@ -26,8 +27,13 @@ export class ProtectedRoute extends React.Component<ProtectedRouteProps> {
       <Route
         {...rest}
         render={props => (
-          <IsAuthenticatedQuery fetchPolicy="network-only">
-            {({ data }) => {
+          <IsAuthenticatedQuery fetchPolicy="network-only" passLoading>
+            {({ data, loading }) => {
+              if (loading) {
+                // we can not render anything until we do not known if customer is authenticated or not
+                return <Loader />;
+              }
+
               if (data.customer) {
                 return <Component {...props} />;
               }

--- a/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
+++ b/packages/falcon-front-kit/src/Routes/ProtectedRoute.tsx
@@ -27,7 +27,7 @@ export class ProtectedRoute extends React.Component<ProtectedRouteProps> {
       <Route
         {...rest}
         render={props => (
-          <IsAuthenticatedQuery fetchPolicy="network-only" passLoading>
+          <IsAuthenticatedQuery passLoading>
             {({ data, loading }) => {
               if (loading) {
                 // we can not render anything until we do not known if customer is authenticated or not

--- a/packages/falcon-magento2-api/src/index.ts
+++ b/packages/falcon-magento2-api/src/index.ts
@@ -952,8 +952,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
         await this.ensureCart();
       }
 
-      // true when user signed in correctly
-      return true;
+      return this.customer();
     } catch (e) {
       // todo: use new version of error handler
       // wrong password or login is not an internal error.

--- a/packages/falcon-shop-data/src/Address/AddAddressMutation.tsx
+++ b/packages/falcon-shop-data/src/Address/AddAddressMutation.tsx
@@ -18,7 +18,8 @@ export type AddAddressResponse = {
 export class AddAddressMutation extends Mutation<AddAddressResponse, OperationInput<AddAddressInput>> {
   static defaultProps = {
     mutation: ADD_ADDRESS,
-    refetchQueries: ['AddressList']
+    refetchQueries: ['AddressList'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -27,5 +28,6 @@ export const useAddAddressMutation = (
 ) =>
   useMutation(ADD_ADDRESS, {
     refetchQueries: ['AddressList'],
+    awaitRefetchQueries: true,
     ...options
   });

--- a/packages/falcon-shop-data/src/Address/EditAddressMutation.tsx
+++ b/packages/falcon-shop-data/src/Address/EditAddressMutation.tsx
@@ -18,7 +18,8 @@ export type EditAddressResponse = {
 export class EditAddressMutation extends Mutation<EditAddressResponse, OperationInput<EditAddressInput>> {
   static defaultProps = {
     mutation: EDIT_ADDRESS,
-    refetchQueries: ['AddressList']
+    refetchQueries: ['AddressList'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -27,5 +28,6 @@ export const useEditAddressMutation = (
 ) =>
   useMutation(EDIT_ADDRESS, {
     refetchQueries: ['AddressList'],
+    awaitRefetchQueries: true,
     ...options
   });

--- a/packages/falcon-shop-data/src/Address/RemoveAddressMutation.tsx
+++ b/packages/falcon-shop-data/src/Address/RemoveAddressMutation.tsx
@@ -18,6 +18,7 @@ export type RemoveAddressVariables = {
 export class RemoveAddressMutation extends Mutation<RemoveAddressResponse, RemoveAddressVariables> {
   static defaultProps = {
     mutation: REMOVE_ADDRESS,
-    refetchQueries: ['AddressList']
+    refetchQueries: ['AddressList'],
+    awaitRefetchQueries: true
   };
 }

--- a/packages/falcon-shop-data/src/Cart/AddToCartMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/AddToCartMutation.tsx
@@ -23,7 +23,8 @@ export type AddToCartResponse = {
 export class AddToCartMutation extends Mutation<AddToCartResponse, OperationInput<AddToCartInput>> {
   static defaultProps = {
     mutation: ADD_TO_CART,
-    refetchQueries: ['MiniCart', 'Cart']
+    refetchQueries: ['MiniCart', 'Cart'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -32,5 +33,6 @@ export const useAddToCartMutation = (
 ) =>
   useMutation(ADD_TO_CART, {
     refetchQueries: ['MiniCart', 'Cart'],
+    awaitRefetchQueries: true,
     ...options
   });

--- a/packages/falcon-shop-data/src/Cart/ApplyCouponMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/ApplyCouponMutation.tsx
@@ -15,6 +15,7 @@ export type ApplyCouponResult = {
 export class ApplyCouponMutation extends Mutation<ApplyCouponResult, OperationInput<CouponInput>> {
   static defaultProps = {
     mutation: APPLY_COUPON,
-    refetchQueries: ['Cart']
+    refetchQueries: ['Cart'],
+    awaitRefetchQueries: true
   };
 }

--- a/packages/falcon-shop-data/src/Cart/CancelCouponMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/CancelCouponMutation.tsx
@@ -14,6 +14,7 @@ export type CancelCouponResponse = {
 export class CancelCouponMutation extends Mutation<CancelCouponResponse, {}> {
   static defaultProps = {
     mutation: CANCEL_COUPON,
-    refetchQueries: ['Cart']
+    refetchQueries: ['Cart'],
+    awaitRefetchQueries: true
   };
 }

--- a/packages/falcon-shop-data/src/Cart/RemoveCartItemMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/RemoveCartItemMutation.tsx
@@ -19,6 +19,7 @@ export class RemoveCartItemMutation extends Mutation<RemoveCartItemResponse, Ope
   static defaultProps = {
     mutation: REMOVE_CART_ITEM,
     refetchQueries: ['Cart'],
+    awaitRefetchQueries: true,
     update: (
       store: any,
       {

--- a/packages/falcon-shop-data/src/Cart/UpdateCartItemMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/UpdateCartItemMutation.tsx
@@ -17,6 +17,7 @@ export type UpdateCartItemResponse = {
 export class UpdateCartItemMutation extends Mutation<UpdateCartItemResponse, OperationInput<UpdateCartItemInput>> {
   static defaultProps = {
     mutation: UPDATE_CART_ITEM,
-    refetchQueries: ['MiniCart', 'Cart']
+    refetchQueries: ['MiniCart', 'Cart'],
+    awaitRefetchQueries: true
   };
 }

--- a/packages/falcon-shop-data/src/Checkout/PlaceOrderMutation.tsx
+++ b/packages/falcon-shop-data/src/Checkout/PlaceOrderMutation.tsx
@@ -30,7 +30,8 @@ export type PlaceOrderResponse = {
 export class PlaceOrderMutation extends Mutation<PlaceOrderResponse, OperationInput<PlaceOrderInput>> {
   static defaultProps = {
     mutation: PLACE_ORDER,
-    refetchQueries: ['Cart', 'OrderList']
+    refetchQueries: ['Cart', 'OrderList'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -39,5 +40,6 @@ export const usePlaceOrderMutation = (
 ) =>
   useMutation<PlaceOrderResponse, OperationInput<PlaceOrderInput>>(PLACE_ORDER, {
     refetchQueries: ['Cart', 'OrderList'],
+    awaitRefetchQueries: true,
     ...(options || {})
   });

--- a/packages/falcon-shop-data/src/Checkout/SetPaymentMethodMutation.tsx
+++ b/packages/falcon-shop-data/src/Checkout/SetPaymentMethodMutation.tsx
@@ -16,6 +16,7 @@ export type SetPaymentMethodResponse = {
 export class SetPaymentMethodMutation extends Mutation<SetPaymentMethodResponse, SetCheckoutDetailsInput> {
   static defaultProps = {
     mutation: SET_PAYMENT_METHOD,
+    awaitRefetchQueries: true,
     refetchQueries: ['Cart']
   };
 }
@@ -25,5 +26,6 @@ export const useSetPaymentMethodMutation = (
 ) =>
   useMutation<SetPaymentMethodResponse, SetCheckoutDetailsInput>(SET_PAYMENT_METHOD, {
     refetchQueries: ['Cart'],
+    awaitRefetchQueries: true,
     ...(options || {})
   });

--- a/packages/falcon-shop-data/src/Checkout/SetShippingMethodMutation.tsx
+++ b/packages/falcon-shop-data/src/Checkout/SetShippingMethodMutation.tsx
@@ -16,7 +16,8 @@ export type SetShippingMethodResponse = {
 export class SetShippingMethodMutation extends Mutation<SetShippingMethodResponse, SetCheckoutDetailsInput> {
   static defaultProps = {
     mutation: SET_SHIPPING_METHOD,
-    refetchQueries: ['Cart']
+    refetchQueries: ['Cart'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -25,5 +26,6 @@ export const useSetShippingMethodMutation = (
 ) =>
   useMutation<SetShippingMethodResponse, SetCheckoutDetailsInput>(SET_SHIPPING_METHOD, {
     refetchQueries: ['Cart'],
+    awaitRefetchQueries: true,
     ...(options || {})
   });

--- a/packages/falcon-shop-data/src/Customer/EditCustomerMutation.tsx
+++ b/packages/falcon-shop-data/src/Customer/EditCustomerMutation.tsx
@@ -18,7 +18,8 @@ export type EditCustomerResponse = {
 export class EditCustomerMutation extends Mutation<EditCustomerResponse, OperationInput<EditCustomerInput>> {
   static defaultProps = {
     mutation: EDIT_CUSTOMER,
-    refetchQueries: ['Customer', 'CustomerWithAddresses']
+    refetchQueries: ['Customer', 'CustomerWithAddresses'],
+    awaitRefetchQueries: true
   };
 }
 
@@ -27,5 +28,6 @@ export const useEditCustomerMutation = (
 ) =>
   useMutation(EDIT_CUSTOMER, {
     refetchQueries: ['Customer', 'CustomerWithAddresses'],
+    awaitRefetchQueries: true,
     ...options
   });

--- a/packages/falcon-shop-data/src/SignIn/SignInMutation.tsx
+++ b/packages/falcon-shop-data/src/SignIn/SignInMutation.tsx
@@ -1,27 +1,38 @@
 import gql from 'graphql-tag';
 import { useMutation, MutationHookOptions } from '@apollo/react-hooks';
 import { Mutation, OperationInput } from '@deity/falcon-data';
-import { SignInInput } from '@deity/falcon-shop-extension';
+import { SignInInput, Customer } from '@deity/falcon-shop-extension';
+import { GET_IS_AUTHENTICATED } from '../Customer';
 
 export const SIGN_IN = gql`
   mutation SignIn($input: SignInInput!) {
-    signIn(input: $input)
+    signIn(input: $input) {
+      id
+    }
   }
 `;
 
-export type SignInResponse = { signIn: boolean };
+export type SignInResponse = { signIn: Pick<Customer, 'id'> };
+
+const defaultOptions = {
+  refetchQueries: ['Cart', 'Customer'],
+  awaitRefetchQueries: false,
+  update: (store, { data: { signIn: customer } }) => {
+    const data = store.readQuery({ query: GET_IS_AUTHENTICATED });
+    data.customer = customer;
+    store.writeQuery({ query: GET_IS_AUTHENTICATED, data: { ...data } });
+  }
+};
 
 export class SignInMutation extends Mutation<SignInResponse, OperationInput<SignInInput>> {
   static defaultProps = {
     mutation: SIGN_IN,
-    refetchQueries: ['Cart', 'CustomerWithAddresses', 'Customer'],
-    awaitRefetchQueries: false
+    ...defaultOptions
   };
 }
 
 export const useSignInMutation = (options: MutationHookOptions<SignInResponse, OperationInput<SignInInput>> = {}) =>
   useMutation(SIGN_IN, {
-    refetchQueries: ['Cart', 'CustomerWithAddresses', 'Customer'],
-    awaitRefetchQueries: false,
+    ...defaultOptions,
     ...options
   });

--- a/packages/falcon-shop-data/src/SignIn/SignInMutation.tsx
+++ b/packages/falcon-shop-data/src/SignIn/SignInMutation.tsx
@@ -14,12 +14,14 @@ export type SignInResponse = { signIn: boolean };
 export class SignInMutation extends Mutation<SignInResponse, OperationInput<SignInInput>> {
   static defaultProps = {
     mutation: SIGN_IN,
-    refetchQueries: ['Cart', 'CustomerWithAddresses', 'Customer']
+    refetchQueries: ['Cart', 'CustomerWithAddresses', 'Customer'],
+    awaitRefetchQueries: false
   };
 }
 
 export const useSignInMutation = (options: MutationHookOptions<SignInResponse, OperationInput<SignInInput>> = {}) =>
   useMutation(SIGN_IN, {
     refetchQueries: ['Cart', 'CustomerWithAddresses', 'Customer'],
+    awaitRefetchQueries: false,
     ...options
   });

--- a/packages/falcon-shop-data/src/SignIn/SignOutMutation.tsx
+++ b/packages/falcon-shop-data/src/SignIn/SignOutMutation.tsx
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 import { useMutation, MutationHookOptions } from '@apollo/react-hooks';
 import { Mutation } from '@deity/falcon-data';
+import { GET_IS_AUTHENTICATED } from '../Customer';
 
 export const SIGN_OUT = gql`
   mutation SignOut {
@@ -10,17 +11,25 @@ export const SIGN_OUT = gql`
 
 export type SignOutResponse = { signOut: boolean };
 
+const defaultOptions = {
+  refetchQueries: ['Customer', 'Cart'],
+  awaitRefetchQueries: false,
+  update: store => {
+    const data = store.readQuery({ query: GET_IS_AUTHENTICATED });
+    data.customer = undefined;
+    store.writeQuery({ query: GET_IS_AUTHENTICATED, data });
+  }
+};
+
 export class SignOutMutation extends Mutation<SignOutResponse> {
   static defaultProps = {
     mutation: SIGN_OUT,
-    refetchQueries: ['Customer', 'Cart'],
-    awaitRefetchQueries: false
+    ...defaultOptions
   };
 }
 
 export const useSignOutMutation = (options: MutationHookOptions<SignOutResponse> = {}) =>
   useMutation(SIGN_OUT, {
-    refetchQueries: ['Customer', 'Cart'],
-    awaitRefetchQueries: false,
+    ...defaultOptions,
     ...options
   });

--- a/packages/falcon-shop-data/src/SignIn/SignOutMutation.tsx
+++ b/packages/falcon-shop-data/src/SignIn/SignOutMutation.tsx
@@ -13,12 +13,14 @@ export type SignOutResponse = { signOut: boolean };
 export class SignOutMutation extends Mutation<SignOutResponse> {
   static defaultProps = {
     mutation: SIGN_OUT,
-    refetchQueries: ['Customer', 'Cart']
+    refetchQueries: ['Customer', 'Cart'],
+    awaitRefetchQueries: false
   };
 }
 
 export const useSignOutMutation = (options: MutationHookOptions<SignOutResponse> = {}) =>
   useMutation(SIGN_OUT, {
     refetchQueries: ['Customer', 'Cart'],
+    awaitRefetchQueries: false,
     ...options
   });

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -44,7 +44,7 @@ extend type Mutation {
   applyCoupon(input: CouponInput!): Boolean
   cancelCoupon: Boolean!
   signUp(input: SignUpInput!): Boolean!
-  signIn(input: SignInInput!): Boolean!
+  signIn(input: SignInInput!): Customer!
   signOut: Boolean!
   editCustomer(input: EditCustomerInput!): Customer
   changePassword(input: ChangePasswordInput!): Boolean

--- a/packages/falcon-ui-kit/src/Account/SignInForm.tsx
+++ b/packages/falcon-ui-kit/src/Account/SignInForm.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { FlexLayout, Link } from '@deity/falcon-ui';
 import { T } from '@deity/falcon-i18n';
-import { SignInFormProvider } from '@deity/falcon-front-kit';
+import { SignInFormProvider, FormProviderProps } from '@deity/falcon-front-kit';
 import { ErrorSummary } from '../Error';
 import { FormField, Form, FormProps, PasswordRevealInput, FormSubmit } from '../Forms';
 
 export type SignInFormProps = Partial<FormProps> & {
   onSuccess?: () => Promise<void>;
   onForgotPassword: Function;
+  mutationOptions?: FormProviderProps['mutationOptions'];
 };
 
-export const SignInForm: React.SFC<SignInFormProps> = ({ onSuccess, onForgotPassword, ...formProps }) => (
-  <SignInFormProvider onSuccess={onSuccess}>
+export const SignInForm: React.SFC<SignInFormProps> = ({
+  onSuccess,
+  onForgotPassword,
+  mutationOptions,
+  ...formProps
+}) => (
+  <SignInFormProvider onSuccess={onSuccess} mutationOptions={mutationOptions}>
     {({ status }) => (
       <Form i18nId="signIn" {...formProps}>
         <FormField name="email" type="email" required autoComplete="email" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix/improvement

**What is the current behavior? (You can also link to an open issue here)**
* global `awaitRefetchQueries` setting is ignored
* sometimes multiple page redirection exists when accessing authorized content
* multiple loaders appear when navigating to authorized content 
 
**What is the new behavior (if this is a feature change)?**
* fixed `awaitRefetchQueries` setting - it needs to be set locally because of https://github.com/apollographql/react-apollo/issues/2643
* fixed/improved app behaviors when signing in / signing out
  * rendering the correct page (handling `?next=[redirect to page url]`)
  * no page blinking
  * no multiple redirects
  * no loaders during page transition


**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

**Other information:**
