### PR TITLE
Sidebar close icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 - fixed incompatible `css` prop typings ([#645](https://github.com/deity-io/falcon/pull/645))
 - added `console.error` when an icon is not defined in the theme during development ([#682](https://github.com/deity-io/falcon/pull/682))
 - improved typings ([#669](https://github.com/deity-io/falcon/pull/669))
-  * renamed `ThemedComponentPropsWithVariants` to `ComponentTheme`
-  * renamed `ThemedComponentProps` to `ThemingProps`
-  * renamed `BaseThemedComponentProps` to `BaseThemingProps`
+  - renamed `ThemedComponentPropsWithVariants` to `ComponentTheme`
+  - renamed `ThemedComponentProps` to `ThemingProps`
+  - renamed `BaseThemedComponentProps` to `BaseThemingProps`
 - added `noScrollbars` css generation function ([#742](https://github.com/deity-io/falcon/pull/742))
 
 ### Falcon E-commerce UI Kit discontinued
@@ -68,6 +68,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 - fixed `ProductCard` component which should not require `thumbnail` ([#685](https://github.com/deity-io/falcon/pull/685))
 - integrated `FormSubmit` with Formik, which allows it to hook into form state ([#548](https://github.com/deity-io/falcon/pull/548))
 - updated Formik to version 2.0 ([#705](https://github.com/deity-io/falcon/pull/705))
+- moved sidebar close icon from `Sidebar` to `SidebarLayout` ([#753](https://github.com/deity-io/falcon/pull/753))
 
 ### Falcon Data v1.0.0
 

--- a/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Category/Category.js
@@ -60,7 +60,7 @@ const CategoryPage = ({ match: { params } }) => (
                             <React.Fragment>
                               <Button onClick={toggle}>Filters</Button>
                               <Sidebar isOpen={on} side="left" close={toggle}>
-                                <SidebarLayout title="Filters">
+                                <SidebarLayout title="Filters" onClose={toggle}>
                                   <Filters data={filtersData} px="md" />
                                 </SidebarLayout>
                               </Sidebar>

--- a/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
@@ -34,7 +34,7 @@ export default ({ contentType, open, close }) => {
           {t => (
             <React.Fragment>
               <Deferred type={SIDEBAR_TYPE.cart} until={contentType} css={{ height: '100%' }}>
-                <SidebarLayout title={t('miniCart.title')}>
+                <SidebarLayout title={t('miniCart.title')} onClose={close}>
                   <MiniCartQuery>
                     {({ data: { cart = { items: [] } } }) =>
                       cart.items.length > 0 ? (
@@ -47,7 +47,7 @@ export default ({ contentType, open, close }) => {
                 </SidebarLayout>
               </Deferred>
               <Deferred type={SIDEBAR_TYPE.account} until={contentType} css={{ height: '100%' }}>
-                <SidebarLayout title={t('signIn.title')}>
+                <SidebarLayout title={t('signIn.title')} onClose={close}>
                   <SignInForm
                     id="sign-in-sidebar"
                     onSuccess={close}
@@ -59,12 +59,12 @@ export default ({ contentType, open, close }) => {
                 </SidebarLayout>
               </Deferred>
               <Deferred type={SIDEBAR_TYPE.signUp} until={contentType} css={{ height: '100%' }}>
-                <SidebarLayout title={t('signUp.title')}>
+                <SidebarLayout title={t('signUp.title')} onClose={close}>
                   <SignUpForm onSuccess={() => open({ variables: { contentType: SIDEBAR_TYPE.account } })} />
                 </SidebarLayout>
               </Deferred>
               <Deferred type={SIDEBAR_TYPE.forgotPassword} until={contentType} css={{ height: '100%' }}>
-                <SidebarLayout title={t('forgotPassword.title')}>
+                <SidebarLayout title={t('forgotPassword.title')} onClose={close}>
                   <ForgotPasswordForm />
                 </SidebarLayout>
               </Deferred>

--- a/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Sidebar/SidebarContents.js
@@ -33,7 +33,7 @@ export default ({ contentType, open, close }) => {
         <I18n>
           {t => (
             <React.Fragment>
-              <Deferred type={SIDEBAR_TYPE.cart} until={contentType} css={{ height: '100%' }}>
+              <Deferred type={SIDEBAR_TYPE.cart} until={contentType} flex={1}>
                 <SidebarLayout title={t('miniCart.title')} onClose={close}>
                   <MiniCartQuery>
                     {({ data: { cart = { items: [] } } }) =>
@@ -46,7 +46,7 @@ export default ({ contentType, open, close }) => {
                   </MiniCartQuery>
                 </SidebarLayout>
               </Deferred>
-              <Deferred type={SIDEBAR_TYPE.account} until={contentType} css={{ height: '100%' }}>
+              <Deferred type={SIDEBAR_TYPE.account} until={contentType} flex={1}>
                 <SidebarLayout title={t('signIn.title')} onClose={close}>
                   <SignInForm
                     id="sign-in-sidebar"
@@ -58,12 +58,12 @@ export default ({ contentType, open, close }) => {
                   <NewAccount onCreateNewAccount={() => open({ variables: { contentType: SIDEBAR_TYPE.signUp } })} />
                 </SidebarLayout>
               </Deferred>
-              <Deferred type={SIDEBAR_TYPE.signUp} until={contentType} css={{ height: '100%' }}>
+              <Deferred type={SIDEBAR_TYPE.signUp} until={contentType} flex={1}>
                 <SidebarLayout title={t('signUp.title')} onClose={close}>
                   <SignUpForm onSuccess={() => open({ variables: { contentType: SIDEBAR_TYPE.account } })} />
                 </SidebarLayout>
               </Deferred>
-              <Deferred type={SIDEBAR_TYPE.forgotPassword} until={contentType} css={{ height: '100%' }}>
+              <Deferred type={SIDEBAR_TYPE.forgotPassword} until={contentType} flex={1}>
                 <SidebarLayout title={t('forgotPassword.title')} onClose={close}>
                   <ForgotPasswordForm />
                 </SidebarLayout>

--- a/packages/falcon-ui-kit/src/Layouts/SidebarLayout.tsx
+++ b/packages/falcon-ui-kit/src/Layouts/SidebarLayout.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { themed, Box, H3 } from '@deity/falcon-ui';
+import { themed, Box, H3, FlexLayout, Icon } from '@deity/falcon-ui';
 
-const SidebarLayoutInnerDOM: React.SFC<SidebarLayoutProps> = ({ title, children, ...rest }) => (
+const SidebarLayoutInnerDOM: React.SFC<SidebarLayoutProps> = ({ title, onClose, children, ...rest }) => (
   <Box {...rest}>
-    {title && <H3>{title}</H3>}
+    <FlexLayout>
+      <Box flex={1}>{!!title && <H3>{title}</H3>}</Box>
+      <Icon src="close" stroke="black" onClick={onClose} />
+    </FlexLayout>
     <SidebarContentLayout>{children}</SidebarContentLayout>
   </Box>
 );
 
 export type SidebarLayoutProps = {
   title?: string;
+  onClose?: (...args: any) => void;
 };
 export const SidebarLayout = themed<SidebarLayoutProps, any>({
   tag: SidebarLayoutInnerDOM,

--- a/packages/falcon-ui-kit/src/Layouts/SidebarLayout.tsx
+++ b/packages/falcon-ui-kit/src/Layouts/SidebarLayout.tsx
@@ -23,6 +23,7 @@ export const SidebarLayout = themed<SidebarLayoutProps, any>({
       gridRowGap: 'md',
       gridTemplate: 'auto 1fr / 100%',
       css: {
+        width: '100%',
         height: '100%'
       }
     }

--- a/packages/falcon-ui-kit/src/Sidebar/Sidebar.tsx
+++ b/packages/falcon-ui-kit/src/Sidebar/Sidebar.tsx
@@ -2,26 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Sidebar as FalconSidebar, Portal, Backdrop, Icon, Box } from '@deity/falcon-ui';
 
+export type SidebarSide = 'left' | 'right';
 export type SidebarProps = {
   isOpen: boolean;
   side: SidebarSide;
   close: Function;
 };
-export const Sidebar: React.SFC<SidebarProps> = ({ close, isOpen, side, children }) => {
-  const position = sidebarSideToPosition(side);
+export const Sidebar: React.SFC<SidebarProps> = ({ close, isOpen, side, children }) => (
+  <>
+    <FalconSidebar as={Portal} visible={isOpen} side={side}>
+      {children}
+    </FalconSidebar>
+    <Backdrop as={Portal} visible={isOpen} onClick={() => close && close()} />
+  </>
+);
 
-  return (
-    <React.Fragment>
-      <FalconSidebar as={Portal} visible={isOpen} side={side}>
-        <Box position="relative" flex={1}>
-          <Icon src="close" stroke="black" position="absolute" {...position} onClick={() => close && close()} />
-          {children}
-        </Box>
-      </FalconSidebar>
-      <Backdrop as={Portal} visible={isOpen} onClick={() => close && close()} />
-    </React.Fragment>
-  );
-};
 Sidebar.propTypes = {
   isOpen: PropTypes.bool,
   close: PropTypes.func,
@@ -29,16 +24,4 @@ Sidebar.propTypes = {
 };
 Sidebar.defaultProps = {
   side: 'right'
-};
-
-export type SidebarSide = 'left' | 'right';
-const sidebarSideToPosition = (side: SidebarSide) => {
-  if (side === 'left' || side === 'right') {
-    return {
-      top: 4,
-      right: 0
-    };
-  }
-
-  throw new Error(`Unsupported Sidebar position !`);
 };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Small feature change.

**What is the current behavior? (You can also link to an open issue here)**

Sidebar close icon position is hardcoded in ui-kit's `Sidebar`.

**What is the new behavior (if this is a feature change)?**

Sidebar icon is positioned next to title in `SidebarLayout`. If a user wants to use a different layout, they only need to override `SidebarLayout`.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

Wherever the `SidebarLayout` component is used, it should be passed an `onClose` prop to make the close button work.
