### PR TITLE
Dropping Node 8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: ['12', '10', '8', '13']
+        node: ['12', '10', '13']
     name: Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,10 +31,6 @@ before_script:
     - yarn test
     - yarn coverage
 
-Node 8:
-  <<: *job_definition
-  image: node:8
-
 Node 10:
   <<: *job_definition
   image: node:10

--- a/examples/shop-with-blog/client/package.json
+++ b/examples/shop-with-blog/client/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --ext js,jsx,ts,tsx ."
   },
   "engines": {
-    "node": ">=8.10"
+    "node": ">=10.15"
   },
   "dependencies": {
     "cross-env": "5.2.0",

--- a/examples/shop-with-blog/server/package.json
+++ b/examples/shop-with-blog/server/package.json
@@ -12,7 +12,7 @@
     "start:prod": "cross-env NODE_ENV=production node index.js"
   },
   "engines": {
-    "node": ">=8.10"
+    "node": ">=10.15"
   },
   "dependencies": {
     "@deity/falcon-blog-extension": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "yarn-deduplicate": "1.1.1"
   },
   "engines": {
-    "node": ">=8.10",
+    "node": ">=10.15",
     "yarn": ">=1.12"
   },
   "workspaces": [

--- a/packages/create-falcon-app/package.json
+++ b/packages/create-falcon-app/package.json
@@ -12,7 +12,7 @@
     "prepare": "node scripts/prepublish.js"
   },
   "engines": {
-    "node": ">=8.10"
+    "node": ">=10.15"
   },
   "dependencies": {
     "chalk": "2.4.2",


### PR DESCRIPTION
This PR raises the "required minimal node version" check from 8.10 to 10.15 (because `8.x`reaches the end-of-life within a couple of days).

The reason for `10.15` - it was released about a year ago, so there's a higher chance that developers would have it installed on their local machines, hence we would give them less stress during the upgrade. 