### PR TITLE
Improving Coupon type across the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 - introduced Country and Region types to allow fetching more details with address queries ([#609](https://github.com/deity-io/falcon/pull/609))
 - added `@cache` for `Query.productList` query ([#743](https://github.com/deity-io/falcon/pull/743))
 - added `Product.categories` and `Category.{urlPath,image,attributes,seo}` fields ([#743](https://github.com/deity-io/falcon/pull/743))
+- introduced `Coupon` type to be used throughout the Extension ([#764](https://github.com/deity-io/falcon/pull/764))
 
 ### Falcon Server vNext
 

--- a/examples/shop-with-blog/client/src/pages/shop/Cart/components/CartSummary.js
+++ b/examples/shop-with-blog/client/src/pages/shop/Cart/components/CartSummary.js
@@ -56,7 +56,7 @@ const ApplyCouponForm = adopt({
           applyCouponMutation.applyCoupon({
             variables: {
               input: {
-                ...values
+                code: values.couponCode
               }
             }
           });

--- a/packages/falcon-magento2-api/src/index.ts
+++ b/packages/falcon-magento2-api/src/index.ts
@@ -879,7 +879,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
         {
           code: totalsData.couponCode,
           name: totalsData.couponCode,
-          discount: totalsData.discountAmount
+          discount: totalsData.totalSegments.find(({ code }) => code === 'discount').value
         }
       ];
     }

--- a/packages/falcon-magento2-api/src/index.ts
+++ b/packages/falcon-magento2-api/src/index.ts
@@ -873,7 +873,16 @@ module.exports = class Magento2Api extends Magento2ApiBase {
     quoteData.active = quoteData.isActive;
     quoteData.virtual = quoteData.isVirtual;
     quoteData.quoteCurrency = totalsData.quoteCurrencyCode;
-    quoteData.couponCode = totalsData.couponCode;
+
+    if (totalsData.couponCode) {
+      quoteData.coupons = [
+        {
+          code: totalsData.couponCode,
+          name: totalsData.couponCode,
+          discount: totalsData.discountAmount
+        }
+      ];
+    }
 
     // prepare totals
     quoteData.totals = totalsData.totalSegments.map(segment => ({
@@ -1111,10 +1120,20 @@ module.exports = class Magento2Api extends Magento2ApiBase {
   reduceOrder(response) {
     const order = this.convertKeys(response);
     const { extensionAttributes = {}, payment = {}, entityId, incrementId, items, ...orderRest } = order;
+    const coupons = [];
+
+    if (order.discountAmount) {
+      coupons.push({
+        code: order.discountDescription,
+        name: order.discountDescription,
+        discount: order.discountAmount
+      });
+    }
 
     const result = {
       ...orderRest,
       id: entityId,
+      coupons,
       referenceNo: incrementId,
       items: this.convertItemsResponse(items),
       shippingAddress: extensionAttributes.shippingAddress,
@@ -1443,7 +1462,7 @@ module.exports = class Magento2Api extends Magento2ApiBase {
     }
 
     try {
-      return this.putAuth(`${route}/coupons/${input.couponCode}`);
+      return this.putAuth(`${route}/coupons/${input.code}`);
     } catch (e) {
       if (e.statusCode === 404) {
         e.userMessage = true;

--- a/packages/falcon-server/schema.graphql
+++ b/packages/falcon-server/schema.graphql
@@ -8,8 +8,6 @@ schema {
   subscription: Subscription
 }
 
-scalar JSON
-
 type Mutation {
   """
   Sets the locale (for example, "en-US")

--- a/packages/falcon-server/schema.graphql
+++ b/packages/falcon-server/schema.graphql
@@ -8,6 +8,9 @@ schema {
   subscription: Subscription
 }
 
+scalar JSON
+scalar NegativeFloat
+
 type Mutation {
   """
   Sets the locale (for example, "en-US")

--- a/packages/falcon-server/src/index.ts
+++ b/packages/falcon-server/src/index.ts
@@ -17,7 +17,7 @@ import { ApolloServer } from 'apollo-server-koa';
 import { KeyValueCache } from 'apollo-server-caching';
 import { ApolloError } from 'apollo-server-errors';
 import { EventEmitter2 } from 'eventemitter2';
-import { JSONResolver } from 'graphql-scalars';
+import { JSONResolver, JSONDefinition, NegativeFloatResolver, NegativeFloatTypeDefinition } from 'graphql-scalars';
 import Cookies from 'cookies';
 import cors from '@koa/cors';
 import Koa from 'koa';
@@ -143,7 +143,7 @@ export class FalconServer {
     const dynamicRouteResolver = new DynamicRouteResolver();
 
     return {
-      schemas: [BaseSchema],
+      schemas: [JSONDefinition, NegativeFloatTypeDefinition, BaseSchema],
       dataSources: () => {
         this.logger.debug('Instantiating GraphQL DataSources');
         const dataSources = {};
@@ -190,7 +190,8 @@ export class FalconServer {
           BackendConfig: {
             activeLocale: this.activeLocaleResolver()
           },
-          JSON: JSONResolver
+          JSON: JSONResolver,
+          NegativeFloat: NegativeFloatResolver
         }
       ],
       extraResolvers: [...this.apiContainer.resolvers],

--- a/packages/falcon-server/src/index.ts
+++ b/packages/falcon-server/src/index.ts
@@ -17,7 +17,7 @@ import { ApolloServer } from 'apollo-server-koa';
 import { KeyValueCache } from 'apollo-server-caching';
 import { ApolloError } from 'apollo-server-errors';
 import { EventEmitter2 } from 'eventemitter2';
-import { JSONResolver, JSONDefinition, NegativeFloatResolver, NegativeFloatTypeDefinition } from 'graphql-scalars';
+import { JSONResolver, NegativeFloatResolver } from 'graphql-scalars';
 import Cookies from 'cookies';
 import cors from '@koa/cors';
 import Koa from 'koa';
@@ -143,7 +143,7 @@ export class FalconServer {
     const dynamicRouteResolver = new DynamicRouteResolver();
 
     return {
-      schemas: [JSONDefinition, NegativeFloatTypeDefinition, BaseSchema],
+      schemas: [BaseSchema],
       dataSources: () => {
         this.logger.debug('Instantiating GraphQL DataSources');
         const dataSources = {};

--- a/packages/falcon-shop-data/src/Cart/CancelCouponMutation.tsx
+++ b/packages/falcon-shop-data/src/Cart/CancelCouponMutation.tsx
@@ -1,9 +1,10 @@
 import gql from 'graphql-tag';
-import { Mutation } from '@deity/falcon-data';
+import { Mutation, OperationInput } from '@deity/falcon-data';
+import { CouponInput } from '@deity/falcon-shop-extension';
 
 export const CANCEL_COUPON = gql`
-  mutation CancelCoupon {
-    cancelCoupon
+  mutation CancelCoupon($input: CouponInput!) {
+    cancelCoupon(input: $input)
   }
 `;
 
@@ -11,7 +12,7 @@ export type CancelCouponResponse = {
   cancelCoupon: boolean;
 };
 
-export class CancelCouponMutation extends Mutation<CancelCouponResponse, {}> {
+export class CancelCouponMutation extends Mutation<CancelCouponResponse, OperationInput<CouponInput>> {
   static defaultProps = {
     mutation: CANCEL_COUPON,
     refetchQueries: ['Cart'],

--- a/packages/falcon-shop-data/src/Cart/CartQuery.tsx
+++ b/packages/falcon-shop-data/src/Cart/CartQuery.tsx
@@ -7,7 +7,11 @@ export const GET_CART = gql`
     cart {
       itemsQty
       quoteCurrency
-      couponCode
+      coupons {
+        name
+        code
+        discount
+      }
       totals {
         code
         title
@@ -31,7 +35,7 @@ export const GET_CART = gql`
 `;
 
 export type CartResponse = {
-  cart: Pick<Cart, 'itemsQty' | 'itemsCount' | 'quoteCurrency' | 'couponCode' | 'totals'> & {
+  cart: Pick<Cart, 'itemsQty' | 'itemsCount' | 'quoteCurrency' | 'coupons' | 'totals'> & {
     items: Pick<CartItem, 'itemId' | 'sku' | 'qty' | 'name' | 'price' | 'rowTotalInclTax' | 'thumbnailUrl'> & {
       itemOptions: Pick<CartItemOption, 'label' | 'value'>[];
     };

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -468,7 +468,7 @@ type Cart {
 type Coupon {
   name: String
   code: String!
-  discount: Float
+  discount: NegativeFloat
 }
 
 type CartItem {

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -42,7 +42,7 @@ extend type Mutation {
   updateCartItem(input: UpdateCartItemInput!): CartItemPayload
   removeCartItem(input: RemoveCartItemInput!): RemoveCartItemPayload
   applyCoupon(input: CouponInput!): Boolean
-  cancelCoupon(input: CouponInput): Boolean!
+  cancelCoupon(input: CouponInput!): Boolean!
   signUp(input: SignUpInput!): Boolean!
   signIn(input: SignInInput!): Customer!
   signOut: Boolean!

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -42,7 +42,7 @@ extend type Mutation {
   updateCartItem(input: UpdateCartItemInput!): CartItemPayload
   removeCartItem(input: RemoveCartItemInput!): RemoveCartItemPayload
   applyCoupon(input: CouponInput!): Boolean
-  cancelCoupon(input: CouponInput!): Boolean!
+  cancelCoupon(input: CouponInput!): Boolean
   signUp(input: SignUpInput!): Boolean!
   signIn(input: SignInInput!): Customer!
   signOut: Boolean!

--- a/packages/falcon-shop-extension/schema.graphql
+++ b/packages/falcon-shop-extension/schema.graphql
@@ -42,7 +42,7 @@ extend type Mutation {
   updateCartItem(input: UpdateCartItemInput!): CartItemPayload
   removeCartItem(input: RemoveCartItemInput!): RemoveCartItemPayload
   applyCoupon(input: CouponInput!): Boolean
-  cancelCoupon: Boolean!
+  cancelCoupon(input: CouponInput): Boolean!
   signUp(input: SignUpInput!): Boolean!
   signIn(input: SignInInput!): Customer!
   signOut: Boolean!
@@ -304,7 +304,7 @@ type Order {
   paymentMethodName: String
   shippingAddress: Address
   billingAddress: Address
-  couponCode: String
+  coupons: [Coupon!]
 }
 
 """
@@ -461,8 +461,14 @@ type Cart {
   itemsQty: Int!
   totals: [CartTotal!]!
   quoteCurrency: String @deprecated(reason: "Use ShopConfig.activeCurrency")
-  couponCode: String
+  coupons: [Coupon!]
   billingAddress: Address
+}
+
+type Coupon {
+  name: String
+  code: String!
+  discount: Float
 }
 
 type CartItem {
@@ -554,7 +560,7 @@ input RemoveCartItemInput {
 }
 
 input CouponInput {
-  couponCode: String!
+  code: String!
 }
 
 type CartItemPayload {

--- a/packages/falcon-shop-extension/src/types.ts
+++ b/packages/falcon-shop-extension/src/types.ts
@@ -147,8 +147,14 @@ export type Cart = {
   totals: CartTotal[];
   /** @deprecated Use ShopConfig.activeCurrency */
   quoteCurrency: string;
-  couponCode: string;
+  coupons: Coupon[];
   billingAddress: Address;
+};
+
+export type Coupon = {
+  code: string;
+  name?: string;
+  discount?: number;
 };
 
 export type CartItem = {
@@ -194,7 +200,7 @@ export type CartTotal = {
 } & GraphQLBase;
 
 export type CouponInput = {
-  couponCode: string;
+  code: string;
 };
 
 export type CartItemPayload = {
@@ -430,7 +436,7 @@ export type Order = {
   billingAddress?: Address;
   shippingDescription?: string;
   shippingAddress?: Address;
-  couponCode?: string;
+  coupons?: Coupon[];
 };
 
 export type OrderItem = {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
Feature. Having a `couponCode` string field on Cart/Order is not enough for advanced templates.
This PR introduces `Coupon` type for Shop Extension.

**What is the new behavior (if this is a feature change)?**
This PR allows using multiple coupon codes for the cart (if backend supports it, like WooCommerce). Allows removing a specified coupon using its code.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
Yes
