### PR TITLE
FIx a11y issues with the number input

### DIFF
--- a/packages/falcon-ui/package.json
+++ b/packages/falcon-ui/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.6.3",
+    "@deity/falcon-i18n": "^1.0.0",
     "@emotion/cache": "10.0.19",
     "@emotion/core": "10.0.21",
     "@emotion/is-prop-valid": "0.8.3",

--- a/packages/falcon-ui/package.json
+++ b/packages/falcon-ui/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@babel/runtime": "7.6.3",
-    "@deity/falcon-i18n": "^1.0.0",
     "@emotion/cache": "10.0.19",
     "@emotion/core": "10.0.21",
     "@emotion/is-prop-valid": "0.8.3",

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { I18n } from '@deity/falcon-i18n';
 import { themed, extractThemableProps } from '../theme';
 import { Box } from './Box';
 import { Icon } from './Icon';
@@ -21,6 +20,8 @@ function triggerChange(element: any, value: any) {
 
 type NumberInputInnerDOMProps = {
   invalid?: boolean;
+  increaseText?: string;
+  decreaseText?: string;
 } & React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
@@ -80,38 +81,34 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
   };
 
   render() {
-    const { className, invalid, min, max, value, ...remaining } = this.props;
+    const { className, invalid, min, max, increaseText, decreaseText, value, ...remaining } = this.props;
     const { themableProps, rest } = extractThemableProps(remaining);
     const currentValue = this.inputRef.current ? this.inputRef.current.value : value;
 
     return (
-      <I18n>
-        {t => (
-          <Box {...themableProps} className={className}>
-            <button
-              type="button"
-              onClick={this.stepDown}
-              aria-label={t('quantity.decrease')}
-              className="-inner-input-step-down-element"
-              disabled={currentValue <= min}
-            >
-              <Icon src="numberInputDown" fallback="−" />
-            </button>
+      <Box {...themableProps} className={className}>
+        <button
+          type="button"
+          onClick={this.stepDown}
+          aria-label={decreaseText}
+          className="-inner-input-step-down-element"
+          disabled={currentValue <= min}
+        >
+          <Icon src="numberInputDown" fallback="−" />
+        </button>
 
-            <input ref={this.inputRef} min={min} value={value} type="number" {...rest} />
+        <input ref={this.inputRef} min={min} value={value} type="number" {...rest} />
 
-            <button
-              type="button"
-              onClick={this.stepUp}
-              aria-label={t('quantity.increase')}
-              className="-inner-input-step-up-element"
-              disabled={max && currentValue >= max}
-            >
-              <Icon src="numberInputUp" fallback="+" />
-            </button>
-          </Box>
-        )}
-      </I18n>
+        <button
+          type="button"
+          onClick={this.stepUp}
+          aria-label={increaseText}
+          className="-inner-input-step-up-element"
+          disabled={max && currentValue >= max}
+        >
+          <Icon src="numberInputUp" fallback="+" />
+        </button>
+      </Box>
     );
   }
 }
@@ -121,7 +118,9 @@ export const NumberInput = themed({
 
   defaultProps: {
     invalid: false,
-    min: 1
+    min: 1,
+    increaseText: 'Increase Quantity',
+    decreaseText: 'Decrease Quantity'
   },
 
   defaultTheme: {

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -22,6 +22,7 @@ function triggerChange(element: any, value: any) {
 type NumberInputInnerDOMProps = {
   invalid?: boolean;
   min?: number;
+  max?: number | undefined;
 } & React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -84,13 +84,13 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
 
     return (
       <Box {...themableProps} className={className}>
-        <button type="button" aria-hidden onClick={this.stepDown} className="-inner-input-step-down-element">
+        <button type="button" onClick={this.stepDown} aria-label="Decrease quantity" className="-inner-input-step-down-element">
           <Icon src="numberInputDown" fallback="−" />
         </button>
 
         <input ref={this.inputRef} min={5} type="number" {...rest} />
 
-        <button type="button" aria-hidden onClick={this.stepUp} className="-inner-input-step-up-element">
+        <button type="button" onClick={this.stepUp} aria-label="Increase quantity" className="-inner-input-step-up-element">
           <Icon src="numberInputUp" fallback="+" />
         </button>
       </Box>
@@ -103,7 +103,7 @@ export const NumberInput = themed({
 
   defaultProps: {
     invalid: false,
-    readOnly: true
+    readOnly: false
   },
 
   defaultTheme: {

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { I18n } from '@deity/falcon-i18n';
 import { themed, extractThemableProps } from '../theme';
 import { Box } from './Box';
 import { Icon } from './Icon';
@@ -20,6 +21,7 @@ function triggerChange(element: any, value: any) {
 
 type NumberInputInnerDOMProps = {
   invalid?: boolean;
+  min?: number;
 } & React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
@@ -79,21 +81,38 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
   };
 
   render() {
-    const { className, invalid, ...remaining } = this.props;
+    const { className, invalid, min, max, ...remaining } = this.props;
     const { themableProps, rest } = extractThemableProps(remaining);
+    const currentValue = this.inputRef.current.value;
 
     return (
-      <Box {...themableProps} className={className}>
-        <button type="button" onClick={this.stepDown} aria-label="Decrease quantity" className="-inner-input-step-down-element">
-          <Icon src="numberInputDown" fallback="−" />
-        </button>
+      <I18n>
+        {t => (
+          <Box {...themableProps} className={className}>
+            <button
+              type="button"
+              onClick={this.stepDown}
+              aria-label={t('quantity.decrease')}
+              className="-inner-input-step-down-element"
+              disabled={parseInt(currentValue, 2) <= min}
+            >
+              <Icon src="numberInputDown" fallback="−" />
+            </button>
 
-        <input ref={this.inputRef} min={5} type="number" {...rest} />
+            <input ref={this.inputRef} min={min} type="number" {...rest} />
 
-        <button type="button" onClick={this.stepUp} aria-label="Increase quantity" className="-inner-input-step-up-element">
-          <Icon src="numberInputUp" fallback="+" />
-        </button>
-      </Box>
+            <button
+              type="button"
+              onClick={this.stepUp}
+              aria-label={t('quantity.increase')}
+              className="-inner-input-step-up-element"
+              disabled={max && parseInt(currentValue, 2) >= max}
+            >
+              <Icon src="numberInputUp" fallback="+" />
+            </button>
+          </Box>
+        )}
+      </I18n>
     );
   }
 }
@@ -103,7 +122,7 @@ export const NumberInput = themed({
 
   defaultProps: {
     invalid: false,
-    readOnly: false
+    min: 1
   },
 
   defaultTheme: {
@@ -158,6 +177,9 @@ export const NumberInput = themed({
           lineHeight: 1,
           ':hover': {
             background: theme.colors.secondary
+          },
+          ':disabled': {
+            opacity: '0.5'
           }
         },
         '.-inner-input-step-down-element': {

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -21,8 +21,6 @@ function triggerChange(element: any, value: any) {
 
 type NumberInputInnerDOMProps = {
   invalid?: boolean;
-  min?: number;
-  max?: number | undefined;
 } & React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
@@ -82,9 +80,9 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
   };
 
   render() {
-    const { className, invalid, min, max, ...remaining } = this.props;
+    const { className, invalid, min, max, value, ...remaining } = this.props;
     const { themableProps, rest } = extractThemableProps(remaining);
-    const currentValue = this.inputRef.current.value;
+    const currentValue = this.inputRef.current ? this.inputRef.current.value : value;
 
     return (
       <I18n>
@@ -95,19 +93,19 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
               onClick={this.stepDown}
               aria-label={t('quantity.decrease')}
               className="-inner-input-step-down-element"
-              disabled={parseInt(currentValue, 2) <= min}
+              disabled={currentValue <= min}
             >
               <Icon src="numberInputDown" fallback="−" />
             </button>
 
-            <input ref={this.inputRef} min={min} type="number" {...rest} />
+            <input ref={this.inputRef} min={min} value={value} type="number" {...rest} />
 
             <button
               type="button"
               onClick={this.stepUp}
               aria-label={t('quantity.increase')}
               className="-inner-input-step-up-element"
-              disabled={max && parseInt(currentValue, 2) >= max}
+              disabled={max && currentValue >= max}
             >
               <Icon src="numberInputUp" fallback="+" />
             </button>

--- a/packages/falcon-ui/src/components/NumberInput.tsx
+++ b/packages/falcon-ui/src/components/NumberInput.tsx
@@ -97,7 +97,7 @@ class NumberInputInnerDOM extends React.Component<NumberInputInnerDOMProps> {
           <Icon src="numberInputDown" fallback="−" />
         </button>
 
-        <input ref={this.inputRef} min={min} value={value} type="number" {...rest} />
+        <input ref={this.inputRef} min={min} max={max} value={value} type="number" {...rest} />
 
         <button
           type="button"


### PR DESCRIPTION
I've removed the read-only as a default prop (it was added here - https://github.com/deity-io/falcon/commit/43a72f0a9248ccfaab7adae5d682aa94c3aad20b#diff-3c6e5855bfb17f965488c8202f5af42f).

I've also removed the `aria-hidden` from the qty buttons. In my opinion, they should be able to be picked up by assistive technology...especially if the input is read-only.

I've also added aria labels and disable the input buttons when they have reached their min / max value

Fixes issue:
Closes #735 

### Please check if the PR fulfills these requirements ###

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Changelog have been added / updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

**Other information:**
