### PR TITLE
Fixing cache queue error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Versions marked with a number and date (e.g. Falcon Client v0.1.0 (2018-10-05)) 
 - added TTL option for cache tags ([#549](https://github.com/deity-io/falcon/pull/549))
 - added optional `ApiDataSource.getExtraResolvers` static method to define extra resolvers ([#557](https://github.com/deity-io/falcon/pull/557))
 - added re-export of all internally used components and helper utils ([#686](https://github.com/deity-io/falcon/pull/686))
+- fixed the issue with the Cache queue and its error handling ([#767](https://github.com/deity-io/falcon/pull/767))
 
 ### Falcon Logger vNext
 

--- a/packages/falcon-server-env/src/cache/Cache.ts
+++ b/packages/falcon-server-env/src/cache/Cache.ts
@@ -51,9 +51,14 @@ export class Cache<V = any> implements KeyValueCache<V> {
       return this.activeGetRequests.get(key) as Promise<V>;
     }
 
-    this.activeGetRequests.set(key, this.createGetRequest(key, setOptions));
-    const result = await this.activeGetRequests.get(key);
-    this.activeGetRequests.delete(key);
+    let result: V;
+
+    try {
+      this.activeGetRequests.set(key, this.createGetRequest(key, setOptions));
+      result = await this.activeGetRequests.get(key);
+    } finally {
+      this.activeGetRequests.delete(key);
+    }
 
     return result as V;
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements ###

- [x] The commit message follows our guidelines
- [x] Changelog have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
Bugfix

**What is the current behavior? (You can also link to an open issue here)**
When the Cache getter was called with `fetchData` setter callback option - this callback may throw an error and internal "callback queue" wasn't cleared after that (so the app was stuck) 

**What is the new behavior (if this is a feature change)?**
Using `try/finally` to remove the failing cache call from the queue in any case.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

## To test/verify the existing issue
- Run both Falcon apps (from the example folder)
- Load the application normally
- Disable network connections for Falcon-Server (like disabling the wifi)
- Visit the non-cached page - **See the error**
- Enable network for Falcon-Server
- Reload the page - **See the error**
