### PR TITLE
style: fix constant typo in 'BlogPostExcerpt' component

### DIFF
--- a/packages/falcon-ecommerce-uikit/src/Blog/BlogPostExcerpt.tsx
+++ b/packages/falcon-ecommerce-uikit/src/Blog/BlogPostExcerpt.tsx
@@ -6,7 +6,7 @@ import { BlogPostExcerptType } from './BlogPostsQuery';
 import { DateFormat } from '../Locale';
 import { toGridTemplate } from '../helpers';
 
-const BlogPostEcerptArea = {
+const BlogPostExcerptArea = {
   image: 'image',
   title: 'title',
   date: 'date',
@@ -24,11 +24,11 @@ const blogPostExcerptLayout: DefaultThemeProps = {
     gridTemplate: {
       xs: toGridTemplate([
         [ '1fr',                      ],
-        [ BlogPostEcerptArea.image    ],
-        [ BlogPostEcerptArea.date     ],
-        [ BlogPostEcerptArea.title    ],
-        [ BlogPostEcerptArea.excerpt  ],
-        [ BlogPostEcerptArea.readMore ]
+        [ BlogPostExcerptArea.image    ],
+        [ BlogPostExcerptArea.date     ],
+        [ BlogPostExcerptArea.title    ],
+        [ BlogPostExcerptArea.excerpt  ],
+        [ BlogPostExcerptArea.readMore ]
       ])
     },
     css: {
@@ -43,15 +43,15 @@ export const BlogPostExcerpt: React.SFC<{ excerpt: BlogPostExcerptType }> = ({ e
       {excerpt.image && (
         <Image
           css={{ height: 300 }}
-          gridArea={BlogPostEcerptArea.image}
+          gridArea={BlogPostExcerptArea.image}
           src={excerpt.image.url}
           alt={excerpt.image.description}
         />
       )}
-      <H3 gridArea={BlogPostEcerptArea.title}>{excerpt.title}</H3>
-      <DateFormat gridArea={BlogPostEcerptArea.date} value={excerpt.date} />
-      <Text gridArea={BlogPostEcerptArea.excerpt}>{excerpt.excerpt}</Text>
-      <Text gridArea={BlogPostEcerptArea.readMore} css={{ textDecoration: 'underline' }}>
+      <H3 gridArea={BlogPostExcerptArea.title}>{excerpt.title}</H3>
+      <DateFormat gridArea={BlogPostExcerptArea.date} value={excerpt.date} />
+      <Text gridArea={BlogPostExcerptArea.excerpt}>{excerpt.excerpt}</Text>
+      <Text gridArea={BlogPostExcerptArea.readMore} css={{ textDecoration: 'underline' }}>
         <T id="blog.readMore" />
       </Text>
     </Link>


### PR DESCRIPTION
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix a typo in a _BlogPostExcerptArea_ constant name within _BlogPostExcerpt.tsx_ file.

**What is the current behavior? (You can also link to an open issue here)**
The original name was "BlogPostEcerptArea".

**What is the new behavior (if this is a feature change)?**
A current, corrected name, is "BlogPostExcerptArea".

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No.

**Other information:**
None.